### PR TITLE
Removed read_word and write_word from imembank

### DIFF
--- a/core/include/core/imembank.h
+++ b/core/include/core/imembank.h
@@ -13,10 +13,8 @@ public:
     virtual bool is_address_in_range(uint16_t addr) const = 0;
 
     virtual uint8_t read_byte(uint16_t addr) const = 0;
-    virtual uint16_t read_word(uint16_t addr) const = 0;
 
     virtual void write_byte(uint16_t addr, uint8_t byte) = 0;
-    virtual void write_word(uint16_t addr, uint16_t word) = 0;
 };
 
 } // namespace n_e_s::core

--- a/core/src/membank.h
+++ b/core/src/membank.h
@@ -34,17 +34,8 @@ public:
         return *get_location(addr);
     }
 
-    uint16_t read_word(uint16_t addr) const override {
-        return read_byte(addr) | read_byte(addr + 1) << 8;
-    }
-
     void write_byte(uint16_t addr, uint8_t byte) override {
         *get_location(addr) = byte;
-    }
-
-    void write_word(uint16_t addr, uint16_t word) override {
-        write_byte(addr, word & 0xFF);
-        write_byte(addr + 1, word >> 8);
     }
 
 private:

--- a/core/src/mmu.cpp
+++ b/core/src/mmu.cpp
@@ -52,7 +52,7 @@ uint8_t Mmu::read_byte(uint16_t addr) const {
 
 uint16_t Mmu::read_word(uint16_t addr) const {
     if (const IMemBank *mem_bank = get_mem_bank(addr)) {
-        return mem_bank->read_word(addr);
+        return mem_bank->read_byte(addr) | mem_bank->read_byte(addr + 1) << 8;
     } else {
         throw std::invalid_argument(invalid_address_msg(addr));
     }
@@ -68,7 +68,8 @@ void Mmu::write_byte(uint16_t addr, uint8_t byte) {
 
 void Mmu::write_word(uint16_t addr, uint16_t word) {
     if (IMemBank *mem_bank = get_mem_bank(addr)) {
-        mem_bank->write_word(addr, word);
+        mem_bank->write_byte(addr, word & 0xFF);
+        mem_bank->write_byte(addr + 1, word >> 8);
     } else {
         throw std::invalid_argument(invalid_address_msg(addr));
     }

--- a/core/test/src/mock_membank.h
+++ b/core/test/src/mock_membank.h
@@ -13,10 +13,8 @@ public:
     MOCK_CONST_METHOD1(is_address_in_range, bool(uint16_t));
 
     MOCK_CONST_METHOD1(read_byte, uint8_t(uint16_t addr));
-    MOCK_CONST_METHOD1(read_word, uint16_t(uint16_t addr));
 
     MOCK_METHOD2(write_byte, void(uint16_t addr, uint8_t byte));
-    MOCK_METHOD2(write_word, void(uint16_t addr, uint16_t word));
 };
 
 } // namespace n_e_s::core::test


### PR DESCRIPTION
Simplified the membank interface by removing read_word and write_word. These functions are now only available from the mmu.