### PR TITLE
Add -Wswitch-enum

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_options(${PROJECT_NAME}
         -Wall
         -Werror
         -Wextra
+        -Wswitch-enum
         -pedantic-errors
 )
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_options(${PROJECT_NAME}
         -Wall
         -Werror
         -Wextra
+        -Wswitch-enum
         -pedantic-errors
 )
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_options(${PROJECT_NAME}
         -Wall
         -Werror
         -Wextra
+        -Wswitch-enum
         -pedantic-errors
 )
 


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html:
> Warn whenever a switch statement has an index of enumerated type and lacks a case for one or more of the named codes of that enumeration. case labels outside the enumeration range also provoke warnings when this option is used. The only difference between -Wswitch and this option is that this option gives a warning about an omitted enumeration code even if there is a default label.