### PR TITLE
Implemented and deployed a mapped membank for the ppu

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,modernize-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,modernize-*,-clang-analyzer-cplusplus.NewDelete'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,modernize-*,-clang-analyzer-cplusplus.NewDelete'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,modernize-*,-clang-analyzer-cplusplus*'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/application/src/main.cpp
+++ b/application/src/main.cpp
@@ -10,14 +10,14 @@
 using namespace n_e_s::core;
 
 int main(int, char **) {
-    MemBankList mem_banks(MemBankFactory::create_nes_mem_banks());
+    std::unique_ptr<IPpu> ppu{PpuFactory::create()};
+
+    MemBankList mem_banks(MemBankFactory::create_nes_mem_banks(ppu.get()));
     std::unique_ptr<IMmu> mmu{MmuFactory::create(std::move(mem_banks))};
 
     Registers registers;
     std::unique_ptr<ICpu> cpu{CpuFactory::create(&registers, mmu.get())};
-    std::unique_ptr<IPpu> ppu{PpuFactory::create()};
     (void)cpu;
-    (void)ppu;
 
     return 0;
 }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,7 +10,9 @@ add_library(${PROJECT_NAME}
     include/core/mmu_factory.h
     include/core/ppu_factory.h
     src/cpu_factory.cpp
+    src/mapped_membank.h
     src/membank.h
+    src/membank_base.h
     src/membank_factory.cpp
     src/mmu.cpp
     src/mmu.h

--- a/core/include/core/ippu.h
+++ b/core/include/core/ippu.h
@@ -10,6 +10,10 @@ class IPpu {
 public:
     virtual ~IPpu() = default;
 
+    virtual uint8_t read_byte(uint16_t addr) const = 0;
+
+    virtual void write_byte(uint16_t addr, uint8_t byte) = 0;
+
     virtual void execute() = 0;
 };
 

--- a/core/include/core/membank_factory.h
+++ b/core/include/core/membank_factory.h
@@ -9,11 +9,13 @@
 
 namespace n_e_s::core {
 
+class IPpu;
+
 using MemBankList = std::vector<std::unique_ptr<IMemBank>>;
 
 class MemBankFactory {
 public:
-    static MemBankList create_nes_mem_banks();
+    static MemBankList create_nes_mem_banks(IPpu *ppu);
 };
 
 } // namespace n_e_s::core

--- a/core/src/mapped_membank.h
+++ b/core/src/mapped_membank.h
@@ -1,0 +1,36 @@
+// Copyright 2018 Robin Linden <dev@robinlinden.eu>
+
+#pragma once
+
+#include "membank_base.h"
+
+#include <cstdint>
+#include <functional>
+
+namespace n_e_s::core {
+
+// A mapped membank will always forward calls to the registered
+// reader and writer.
+template <uint16_t StartAddr, uint16_t EndAddr, uint16_t Size>
+class MappedMemBank : public MemBankBase<StartAddr, EndAddr, Size> {
+public:
+    using ByteReader = std::function<uint8_t(uint16_t)>;
+    using ByteWriter = std::function<void(uint16_t, uint8_t)>;
+
+    MappedMemBank(ByteReader reader, ByteWriter writer)
+            : reader_{std::move(reader)}, writer_{std::move(writer)} {}
+
+    uint8_t read_byte(uint16_t addr) const override {
+        return reader_(addr);
+    }
+
+    void write_byte(uint16_t addr, uint8_t byte) override {
+        writer_(addr, byte);
+    }
+
+private:
+    ByteReader reader_;
+    ByteWriter writer_;
+};
+
+} // namespace n_e_s::core

--- a/core/src/membank.h
+++ b/core/src/membank.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "core/imembank.h"
+#include "membank_base.h"
 
 #include <array>
 #include <cstdint>
@@ -10,25 +10,10 @@
 
 namespace n_e_s::core {
 
-// A memory bank is specified with a start address, end address and size.
-// The object will hold an array of the given size, however the specified
-// address range may be greater than the size. This is to support memory
-// mirroring, meaning that the same memory may be accessed at multiple
-// addresses. For a memory bank to be valid the difference between end and
-// start address has to be evenly dividable by the given size.
 template <uint16_t StartAddr, uint16_t EndAddr, uint16_t Size>
-class MemBank : public IMemBank {
+class MemBank : public MemBankBase<StartAddr, EndAddr, Size> {
 public:
-    static_assert(Size > 0u, "Size must be greater than zero");
-    static_assert(StartAddr <= EndAddr, "Start addr greater than end addr");
-    static_assert((EndAddr - StartAddr + 1u) % Size == 0,
-            "Size does not match address range");
-
     MemBank() : bank_() {}
-
-    bool is_address_in_range(uint16_t addr) const override {
-        return addr >= StartAddr && addr <= EndAddr;
-    }
 
     uint8_t read_byte(uint16_t addr) const override {
         return *get_location(addr);

--- a/core/src/membank_base.h
+++ b/core/src/membank_base.h
@@ -1,0 +1,33 @@
+// Copyright 2018 Robin Linden <dev@robinlinden.eu>
+
+#pragma once
+
+#include "core/imembank.h"
+
+#include <cstdint>
+
+namespace n_e_s::core {
+
+// A memory bank is specified with a start address, end address and size.
+// The object will hold an array of the given size, however the specified
+// address range may be greater than the size. This is to support memory
+// mirroring, meaning that the same memory may be accessed at multiple
+// addresses. For a memory bank to be valid the difference between end and
+// start address has to be evenly dividable by the given size.
+template <uint16_t StartAddr, uint16_t EndAddr, uint16_t Size>
+class MemBankBase : public IMemBank {
+public:
+    static_assert(Size > 0u, "Size must be greater than zero");
+    static_assert(StartAddr <= EndAddr, "Start addr greater than end addr");
+    static_assert((EndAddr - StartAddr + 1u) % Size == 0,
+            "Size does not match address range");
+
+    bool is_address_in_range(uint16_t addr) const override {
+        return addr >= StartAddr && addr <= EndAddr;
+    }
+
+protected:
+    MemBankBase() = default;
+};
+
+} // namespace n_e_s::core

--- a/core/src/membank_factory.cpp
+++ b/core/src/membank_factory.cpp
@@ -2,18 +2,30 @@
 
 #include "core/membank_factory.h"
 
+#include "core/ippu.h"
+
+#include "mapped_membank.h"
 #include "membank.h"
 
 namespace n_e_s::core {
 
-MemBankList MemBankFactory::create_nes_mem_banks() {
+auto create_ppu_reader(IPpu *ppu) {
+    return [=](uint16_t addr) { return ppu->read_byte(addr); };
+}
+
+auto create_ppu_writer(IPpu *ppu) {
+    return [=](uint16_t addr, uint8_t byte) { ppu->write_byte(addr, byte); };
+}
+
+MemBankList MemBankFactory::create_nes_mem_banks(IPpu *ppu) {
     MemBankList mem_banks;
 
     // Ram, repeats every 0x800 byte
     mem_banks.push_back(std::make_unique<MemBank<0x0000, 0x1FFF, 0x800>>());
 
     // Ppu, repeats every 0x8 byte
-    mem_banks.push_back(std::make_unique<MemBank<0x2000, 0x3FFF, 0x8>>());
+    mem_banks.push_back(std::make_unique<MappedMemBank<0x2000, 0x3FFF, 0x8>>(
+            create_ppu_reader(ppu), create_ppu_writer(ppu)));
 
     // Io
     mem_banks.push_back(std::make_unique<MemBank<0x4000, 0x4017, 0x18>>());

--- a/core/src/ppu.cpp
+++ b/core/src/ppu.cpp
@@ -6,6 +6,12 @@ namespace n_e_s::core {
 
 // PPU implementation stuff to be added.
 
+uint8_t Ppu::read_byte(uint16_t) const {
+    return 0u;
+}
+
+void Ppu::write_byte(uint16_t, uint8_t) {}
+
 void Ppu::execute() {}
 
 } // namespace n_e_s::core

--- a/core/src/ppu.h
+++ b/core/src/ppu.h
@@ -10,6 +10,10 @@ class Ppu : public IPpu {
 public:
     Ppu() = default;
 
+    uint8_t read_byte(uint16_t addr) const override;
+
+    void write_byte(uint16_t addr, uint8_t byte) override;
+
     void execute() override;
 };
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${PROJECT_NAME}
     src/main.cpp
     src/mock_membank.h
     src/mock_mmu.h
+    src/mock_ppu.h
     src/test_cpu.cpp
     src/test_mmu.cpp
     src/test_ppu.cpp

--- a/core/test/src/mock_ppu.h
+++ b/core/test/src/mock_ppu.h
@@ -18,4 +18,3 @@ public:
 };
 
 } // namespace n_e_s::core::test
-

--- a/core/test/src/mock_ppu.h
+++ b/core/test/src/mock_ppu.h
@@ -1,0 +1,21 @@
+// Copyright 2018 Robin Linden <dev@robinlinden.eu>
+
+#pragma once
+
+#include "core/ippu.h"
+
+#include <gmock/gmock.h>
+
+namespace n_e_s::core::test {
+
+class MockPpu : public IPpu {
+public:
+    MOCK_CONST_METHOD1(read_byte, uint8_t(uint16_t addr));
+
+    MOCK_METHOD2(write_byte, void(uint16_t addr, uint8_t byte));
+
+    MOCK_METHOD0(execute, void());
+};
+
+} // namespace n_e_s::core::test
+

--- a/core/test/src/test_mmu.cpp
+++ b/core/test/src/test_mmu.cpp
@@ -3,17 +3,39 @@
 #include "core/membank_factory.h"
 #include "core/mmu_factory.h"
 
+#include "mock_ppu.h"
+
 #include <gtest/gtest.h>
 
 using namespace n_e_s::core;
+using namespace n_e_s::core::test;
 
 namespace {
+
+std::vector<uint16_t> get_addr_list() {
+    return {0x0000,
+            0x1000,
+            0x4000,
+            0x5000,
+            0x6000,
+            0x7000,
+            0x8000,
+            0x9000,
+            0xA000,
+            0xB000,
+            0xC000,
+            0xD000,
+            0xF000};
+}
 
 class MmuTest : public ::testing::Test {
 public:
     MmuTest()
-            : mmu{MmuFactory::create(MemBankFactory::create_nes_mem_banks())} {}
+            : ppu{},
+              mmu{MmuFactory::create(
+                      MemBankFactory::create_nes_mem_banks(&ppu))} {}
 
+    MockPpu ppu;
     std::unique_ptr<IMmu> mmu;
 };
 
@@ -27,18 +49,51 @@ public:
 TEST_F(MmuTest, read_write_byte) {
     const uint8_t byte = 0xF0;
 
-    for (uint32_t i = 0; i < 0xFFFF; i += 0x1000) {
-        mmu->write_byte(i, byte);
-        EXPECT_EQ(byte, mmu->read_byte(i));
+    for (uint16_t addr : get_addr_list()) {
+        mmu->write_byte(addr, byte);
+        EXPECT_EQ(byte, mmu->read_byte(addr));
     }
 }
 
 TEST_F(MmuTest, read_write_word) {
     const uint16_t word = 0xF00D;
-    for (uint32_t i = 0; i < 0xFFFF; i += 0x1000) {
-        mmu->write_word(i, word);
-        EXPECT_EQ(word, mmu->read_word(i));
+
+    for (uint16_t addr : get_addr_list()) {
+        mmu->write_word(addr, word);
+        EXPECT_EQ(word, mmu->read_word(addr));
     }
+}
+
+TEST_F(MmuTest, read_write_byte_to_ppu) {
+    const uint8_t byte = 0xAB;
+
+    EXPECT_CALL(ppu, write_byte(0x2000, 0xAB));
+    EXPECT_CALL(ppu, read_byte(0x2000)).WillOnce(testing::Return(0xAB));
+    EXPECT_CALL(ppu, write_byte(0x3000, 0xAB));
+    EXPECT_CALL(ppu, read_byte(0x3000)).WillOnce(testing::Return(0xAB));
+
+    mmu->write_byte(0x2000, byte);
+    EXPECT_EQ(byte, mmu->read_byte(0x2000));
+    mmu->write_byte(0x3000, byte);
+    EXPECT_EQ(byte, mmu->read_byte(0x3000));
+}
+
+TEST_F(MmuTest, read_write_word_to_ppu) {
+    const uint16_t word = 0xF00D;
+
+    EXPECT_CALL(ppu, write_byte(0x2000, 0x0D));
+    EXPECT_CALL(ppu, read_byte(0x2000)).WillOnce(testing::Return(0x0D));
+    EXPECT_CALL(ppu, write_byte(0x2001, 0xF0));
+    EXPECT_CALL(ppu, read_byte(0x2001)).WillOnce(testing::Return(0xF0));
+    EXPECT_CALL(ppu, write_byte(0x3000, 0x0D));
+    EXPECT_CALL(ppu, read_byte(0x3000)).WillOnce(testing::Return(0x0D));
+    EXPECT_CALL(ppu, write_byte(0x3001, 0xF0));
+    EXPECT_CALL(ppu, read_byte(0x3001)).WillOnce(testing::Return(0xF0));
+
+    mmu->write_word(0x2000, word);
+    EXPECT_EQ(word, mmu->read_word(0x2000));
+    mmu->write_word(0x3000, word);
+    EXPECT_EQ(word, mmu->read_word(0x3000));
 }
 
 TEST_F(MmuTest, read_write_byte_io_dev_bank) {
@@ -62,26 +117,6 @@ TEST_F(MmuTest, byte_order) {
 TEST_F(MmuTest, ram_bank_mirroring) {
     const std::vector<uint16_t> addrs{0x100, 0x900, 0x1100, 0x1900};
     const std::vector<uint8_t> bytes{0x1F, 0xCC, 0x01, 0xAB};
-
-    for (uint8_t i = 0; i < addrs.size(); ++i) {
-        mmu->write_byte(addrs[i], bytes[i]);
-
-        for (uint16_t addr : addrs) {
-            EXPECT_EQ(bytes[i], mmu->read_byte(addr));
-        }
-    }
-}
-
-TEST_F(MmuTest, ppu_bank_mirroring) {
-    std::vector<uint16_t> addrs;
-    std::vector<uint8_t> bytes;
-
-    uint16_t addr = 0x2004;
-    for (uint8_t i = 1; i <= 0x80; ++i) {
-        bytes.push_back(i % 0xF);
-        addrs.push_back(addr);
-        addr += 0x40;
-    }
 
     for (uint8_t i = 0; i < addrs.size(); ++i) {
         mmu->write_byte(addrs[i], bytes[i]);


### PR DESCRIPTION
This PR introduces a MappedMemBank class that can be used for memory that is mapped in the CPUs address space but resides on another chip. One such case is the PPU registers.
Unfortunately I had to disable some checks in our clang-tidy configuration due to a warning in google mock. This is a know false positive, see for example https://github.com/abseil/googletest/issues/853. Maybe you have some idea on how we could handle this in a better way?