### PR TITLE
Return unique pointers in factories

### DIFF
--- a/core/include/core/cpu_factory.h
+++ b/core/include/core/cpu_factory.h
@@ -5,11 +5,13 @@
 #include "core/icpu.h"
 #include "core/immu.h"
 
+#include <memory>
+
 namespace n_e_s::core {
 
 class CpuFactory {
 public:
-    static ICpu *create(Registers *registers, IMmu *mmu);
+    static std::unique_ptr<ICpu> create(Registers *registers, IMmu *mmu);
 };
 
 } // namespace n_e_s::core

--- a/core/include/core/mmu_factory.h
+++ b/core/include/core/mmu_factory.h
@@ -5,11 +5,13 @@
 #include "core/immu.h"
 #include "core/membank_factory.h"
 
+#include <memory>
+
 namespace n_e_s::core {
 
 class MmuFactory {
 public:
-    static IMmu *create(MemBankList mem_banks);
+    static std::unique_ptr<IMmu> create(MemBankList mem_banks);
 };
 
 } // namespace n_e_s::core

--- a/core/include/core/ppu_factory.h
+++ b/core/include/core/ppu_factory.h
@@ -5,11 +5,13 @@
 #include "core/immu.h"
 #include "core/ippu.h"
 
+#include <memory>
+
 namespace n_e_s::core {
 
 class PpuFactory {
 public:
-    static IPpu *create();
+    static std::unique_ptr<IPpu> create();
 };
 
 } // namespace n_e_s::core

--- a/core/src/cpu_factory.cpp
+++ b/core/src/cpu_factory.cpp
@@ -6,8 +6,9 @@
 
 namespace n_e_s::core {
 
-ICpu *CpuFactory::create(Registers *const registers, IMmu *const mmu) {
-    return new Mos6502(registers, mmu);
+std::unique_ptr<ICpu> CpuFactory::create(Registers *const registers,
+        IMmu *const mmu) {
+    return std::make_unique<Mos6502>(registers, mmu);
 }
 
 } // namespace n_e_s::core

--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -7,8 +7,8 @@
 
 namespace n_e_s::core {
 
-IMmu *MmuFactory::create(MemBankList mem_banks) {
-    auto mmu = new Mmu();
+std::unique_ptr<IMmu> MmuFactory::create(MemBankList mem_banks) {
+    auto mmu = std::make_unique<Mmu>();
 
     for (std::unique_ptr<IMemBank> &mem_bank : mem_banks) {
         mmu->add_mem_bank(std::move(mem_bank));

--- a/core/src/ppu_factory.cpp
+++ b/core/src/ppu_factory.cpp
@@ -6,8 +6,8 @@
 
 namespace n_e_s::core {
 
-IPpu *PpuFactory::create() {
-    return new Ppu();
+std::unique_ptr<IPpu> PpuFactory::create() {
+    return std::make_unique<Ppu>();
 }
 
 } // namespace n_e_s::core


### PR DESCRIPTION
I think this is better than returning raw pointers. If the user wants to do something else with the pointer (like putting it in a shared pointer) he can just release it from the unique pointer.