### PR TITLE
Update copyright headers

### DIFF
--- a/core/include/core/cpu_factory.h
+++ b/core/include/core/cpu_factory.h
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #pragma once

--- a/core/include/core/mmu_factory.h
+++ b/core/include/core/mmu_factory.h
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #pragma once

--- a/core/include/core/ppu_factory.h
+++ b/core/include/core/ppu_factory.h
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #pragma once

--- a/core/src/cpu_factory.cpp
+++ b/core/src/cpu_factory.cpp
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #include "core/cpu_factory.h"

--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #include "core/mmu_factory.h"

--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #include "mos6502.h"

--- a/core/src/mos6502.h
+++ b/core/src/mos6502.h
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #pragma once

--- a/core/src/opcode.cpp
+++ b/core/src/opcode.cpp
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #include "opcode.h"

--- a/core/src/opcode.h
+++ b/core/src/opcode.h
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #pragma once

--- a/core/src/pipeline.cpp
+++ b/core/src/pipeline.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Robin Linden <dev@robinlinden.eu>
+// Copyright 2018 Evil Corp contributors
 
 #include "pipeline.h"
 

--- a/core/src/pipeline.h
+++ b/core/src/pipeline.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Robin Linden <dev@robinlinden.eu>
+// Copyright 2018 Evil Corp contributors
 
 #pragma once
 

--- a/core/src/ppu_factory.cpp
+++ b/core/src/ppu_factory.cpp
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #include "core/ppu_factory.h"

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -1,3 +1,4 @@
+// Copyright 2018 Evil Corp contributors
 // Copyright 2018 Robin Linden <dev@robinlinden.eu>
 
 #include "core/cpu_factory.h"


### PR DESCRIPTION
From now on, whenever we add a new file, we should only use
`// Copyright 2018 Evil Corp contributors`
and when we touch old files, we should add that line at the top.