### PR TITLE
Use explicit types when not obvious what the type is

### DIFF
--- a/core/src/membank_factory.cpp
+++ b/core/src/membank_factory.cpp
@@ -6,6 +6,7 @@
 #include "membank.h"
 
 namespace n_e_s::core {
+namespace {
 
 auto create_ppu_reader(IPpu *ppu) {
     return [=](uint16_t addr) { return ppu->read_byte(addr); };
@@ -14,6 +15,8 @@ auto create_ppu_reader(IPpu *ppu) {
 auto create_ppu_writer(IPpu *ppu) {
     return [=](uint16_t addr, uint8_t byte) { ppu->write_byte(addr, byte); };
 }
+
+} // namespace
 
 MemBankList MemBankFactory::create_nes_mem_banks(IPpu *ppu) {
     MemBankList mem_banks;

--- a/core/src/mmu.cpp
+++ b/core/src/mmu.cpp
@@ -8,7 +8,7 @@ namespace n_e_s::core {
 namespace {
 
 auto equal(uint16_t addr) {
-    return [=](const auto &mem_bank) {
+    return [=](const std::unique_ptr<IMemBank> &mem_bank) {
         return mem_bank->is_address_in_range(addr);
     };
 }

--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -1,6 +1,6 @@
 #include "core/mmu_factory.h"
-#include "membank.h"
 
+#include "membank.h"
 #include "mmu.h"
 
 namespace n_e_s::core {

--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -66,8 +66,8 @@ Mos6502::Mos6502(Registers *const registers, IMmu *const mmu)
 // Most instruction timings are from https://robinli.eu/f/6502_cpu.txt
 void Mos6502::execute() {
     if (pipeline_.empty()) {
-        const auto raw_opcode{mmu_->read_byte(registers_->pc++)};
-        const auto opcode = decode(raw_opcode);
+        const uint8_t raw_opcode{mmu_->read_byte(registers_->pc++)};
+        const Opcode opcode = decode(raw_opcode);
 
         switch (opcode.instruction) {
         case Instruction::BRK:


### PR DESCRIPTION
Also some accidental drive-by fixes on things not being internally linked when they should be and header grouping.