### PR TITLE
Create a NES abstraction over all machine components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
             - libstdc++-7-dev
       script:
         - CXX=clang++-7 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-        - run-clang-tidy-7.py -q -p . "core|application"
+        - run-clang-tidy-7.py -q -p . "application|core|nes"
 
     - name: "clang-format"
       addons:
@@ -69,7 +69,7 @@ matrix:
             - clang-format
       before_script: []
       script:
-        - find application core -name *.h -o -name *.cpp | xargs clang-format -style=file -i
+        - find application core nes -name *.h -o -name *.cpp | xargs clang-format -style=file -i
         - git diff --exit-code
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,4 @@ enable_testing()
 
 add_subdirectory(application)
 add_subdirectory(core)
+add_subdirectory(nes)

--- a/application/src/main.cpp
+++ b/application/src/main.cpp
@@ -1,22 +1,10 @@
-#include "core/cpu_factory.h"
-#include "core/membank_factory.h"
-#include "core/mmu_factory.h"
-#include "core/ppu_factory.h"
+#include "nes/nes.h"
 
-#include <memory>
-
-using namespace n_e_s::core;
+using namespace n_e_s::nes;
 
 int main(int, char **) {
-    PpuRegisters ppu_registers;
-    std::unique_ptr<IPpu> ppu{PpuFactory::create(&ppu_registers)};
-
-    MemBankList mem_banks = MemBankFactory::create_nes_mem_banks(ppu.get());
-    std::unique_ptr<IMmu> mmu{MmuFactory::create(std::move(mem_banks))};
-
-    Registers registers;
-    std::unique_ptr<ICpu> cpu{CpuFactory::create(&registers, mmu.get())};
-    (void)cpu;
+    Nes nes;
+    (void)nes;
 
     return 0;
 }

--- a/nes/CMakeLists.txt
+++ b/nes/CMakeLists.txt
@@ -1,12 +1,8 @@
-project(n_e_s_application)
+project(n_e_s_nes)
 
-add_executable(${PROJECT_NAME}
-    src/main.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-    PRIVATE
-        n_e_s_nes
+add_library(${PROJECT_NAME}
+    include/nes/nes.h
+    src/nes.cpp
 )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -27,9 +23,23 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_17
 )
 
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        include
+    PRIVATE
+        src
+)
+
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
 )
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        n_e_s_core
+)
+
+add_subdirectory(test)

--- a/nes/include/nes/nes.h
+++ b/nes/include/nes/nes.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <memory>
+
+namespace n_e_s::nes {
+
+class Nes {
+public:
+    Nes();
+    ~Nes();
+
+    void execute();
+    void reset();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace n_e_s::nes

--- a/nes/src/nes.cpp
+++ b/nes/src/nes.cpp
@@ -16,8 +16,9 @@ class Nes::Impl {
 public:
     Impl()
             : ppu_(PpuFactory::create(&ppu_registers_)),
-            mmu_(MmuFactory::create(MemBankFactory::create_nes_mem_banks(ppu_.get()))),
-            cpu_(CpuFactory::create(&registers_, mmu_.get())) {}
+              mmu_(MmuFactory::create(
+                      MemBankFactory::create_nes_mem_banks(ppu_.get()))),
+              cpu_(CpuFactory::create(&registers_, mmu_.get())) {}
 
     void execute() {
         if (cycle_++ % 3 == 0) {
@@ -43,8 +44,7 @@ private:
     uint64_t cycle_{};
 };
 
-Nes::Nes() : impl_(std::make_unique<Impl>()) {
-}
+Nes::Nes() : impl_(std::make_unique<Impl>()) {}
 
 Nes::~Nes() = default;
 

--- a/nes/src/nes.cpp
+++ b/nes/src/nes.cpp
@@ -1,0 +1,59 @@
+#include "nes/nes.h"
+
+#include "core/cpu_factory.h"
+#include "core/icpu.h"
+#include "core/immu.h"
+#include "core/ippu.h"
+#include "core/membank_factory.h"
+#include "core/mmu_factory.h"
+#include "core/ppu_factory.h"
+
+using namespace n_e_s::core;
+
+namespace n_e_s::nes {
+
+class Nes::Impl {
+public:
+    Impl()
+            : ppu_(PpuFactory::create(&ppu_registers_)),
+            mmu_(MmuFactory::create(MemBankFactory::create_nes_mem_banks(ppu_.get()))),
+            cpu_(CpuFactory::create(&registers_, mmu_.get())) {}
+
+    void execute() {
+        if (cycle_++ % 3 == 0) {
+            cpu_->execute();
+        }
+
+        ppu_->execute();
+    }
+
+    void reset() {
+        cpu_->reset();
+    }
+
+private:
+    PpuRegisters ppu_registers_{};
+    std::unique_ptr<IPpu> ppu_;
+
+    std::unique_ptr<IMmu> mmu_;
+
+    Registers registers_{};
+    std::unique_ptr<ICpu> cpu_;
+
+    uint64_t cycle_{};
+};
+
+Nes::Nes() : impl_(std::make_unique<Impl>()) {
+}
+
+Nes::~Nes() = default;
+
+void Nes::execute() {
+    impl_->execute();
+}
+
+void Nes::reset() {
+    impl_->reset();
+}
+
+} // namespace n_e_s::nes

--- a/nes/test/CMakeLists.txt
+++ b/nes/test/CMakeLists.txt
@@ -1,0 +1,55 @@
+include(FetchContent)
+include(GoogleTest)
+
+project(test_n_e_s_nes)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        7515e399436a832a0109d64a70b4e1125568dda5
+)
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+FetchContent_GetProperties(googletest)
+if(NOT googletest_POPULATED)
+    FetchContent_Populate(googletest)
+    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+endif()
+
+add_executable(${PROJECT_NAME}
+    src/main.cpp
+)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(${PROJECT_NAME}
+        PRIVATE
+           -Wall
+           -Werror
+           -Wextra
+           -Wswitch-enum
+           -Wshadow
+           -Wnon-virtual-dtor
+           -pedantic-errors
+    )
+endif()
+
+target_compile_features(${PROJECT_NAME}
+    PRIVATE
+        cxx_std_17
+)
+
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        n_e_s_nes
+        gmock
+)
+
+gtest_discover_tests(${PROJECT_NAME})

--- a/nes/test/src/main.cpp
+++ b/nes/test/src/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I'm thinking this will be a layer you would pass e.g. your controller method as well as a graphics output. If you want to do something fancy with the machine components, you can still link against `n_e_s::core` and view this more as a usage example.

I also think this will be a nice level of abstraction to use for integration/system tests in the future.