### PR TITLE
Check test coverage of everything except dependencies and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - CXX=g++-7 CXXFLAGS="-fprofile-arcs -ftest-coverage" cmake ..
         - make
         - ctest --output-on-failure
-        - gcovr core/CMakeFiles/n_e_s_core.dir/src/ -p --root .. --fail-under-line=95
+        - gcovr -p --root .. --fail-under-line=95 --exclude '_deps/' --exclude '(.+/)?test/'
 
     - name: "clang 7"
       addons: &clang7


### PR DESCRIPTION
Previously we only checked test coverage of core/ and with a weird hard-coded CMake-magic path.