### PR TITLE
Better debug prints of register flags

### DIFF
--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -4,7 +4,6 @@
 #include "mock_mmu.h"
 
 #include <gtest/gtest.h>
-#include <bitset>
 #include <ostream>
 
 using namespace n_e_s::core;
@@ -26,7 +25,16 @@ static void PrintTo(const ICpu::Registers &r, std::ostream *os) {
     *os << " A: " << hex_out_s(r.a);
     *os << " X: " << hex_out_s(r.x);
     *os << " Y: " << hex_out_s(r.y);
-    *os << " P: 0b" << std::bitset<8>(r.p) << std::endl;
+    *os << " P: ";
+    *os << (r.p & N_FLAG ? "N" : "-");
+    *os << (r.p & V_FLAG ? "V" : "-");
+    *os << "-";
+    *os << (r.p & B_FLAG ? "B" : "-");
+    *os << (r.p & D_FLAG ? "D" : "-");
+    *os << (r.p & I_FLAG ? "I" : "-");
+    *os << (r.p & Z_FLAG ? "Z" : "-");
+    *os << (r.p & C_FLAG ? "C" : "-");
+    *os << std::endl;
 }
 
 } // namespace n_e_s::core


### PR DESCRIPTION
This commit will show which flags are set for failing unit tests instead of just the bitmask, for example:
```
Expected: ----N--
Actual:   Z------
```