### PR TITLE
 Set up compiler warnings in separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
         - git diff --exit-code
 
 before_script:
+  - source flags.sh
   - mkdir _build && cd _build
   - eval "${MATRIX_EVAL}"
 

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -9,19 +9,6 @@ target_link_libraries(${PROJECT_NAME}
         n_e_s_nes
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME}
-        PRIVATE
-           -Wall
-           -Werror
-           -Wextra
-           -Wswitch-enum
-           -Wshadow
-           -Wnon-virtual-dtor
-           -pedantic-errors
-    )
-endif()
-
 target_compile_features(${PROJECT_NAME}
     PRIVATE
         cxx_std_17

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -35,19 +35,6 @@ add_library(${PROJECT_NAME}
     src/rom/nrom.h
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME}
-        PRIVATE
-           -Wall
-           -Werror
-           -Wextra
-           -Wswitch-enum
-           -Wshadow
-           -Wnon-virtual-dtor
-           -pedantic-errors
-    )
-endif()
-
 target_compile_features(${PROJECT_NAME}
     PRIVATE
         cxx_std_17

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -29,19 +29,6 @@ add_executable(${PROJECT_NAME}
     src/test_rom.cpp
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME}
-        PRIVATE
-           -Wall
-           -Werror
-           -Wextra
-           -Wswitch-enum
-           -Wshadow
-           -Wnon-virtual-dtor
-           -pedantic-errors
-    )
-endif()
-
 target_compile_features(${PROJECT_NAME}
     PRIVATE
         cxx_std_17

--- a/flags.sh
+++ b/flags.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+add_flag() { CXXFLAGS="$CXXFLAGS $@"; }
+
+add_flag -Wall
+add_flag -Werror
+add_flag -Wextra
+add_flag -Wswitch-enum
+add_flag -Wshadow
+add_flag -Wnon-virtual-dtor
+add_flag -pedantic-errors
+
+export CXXFLAGS=$CXXFLAGS

--- a/flags.sh
+++ b/flags.sh
@@ -5,7 +5,6 @@ add_flag() { CXXFLAGS="$CXXFLAGS $@"; }
 add_flag -Wall
 add_flag -Werror
 add_flag -Wextra
-add_flag -Wswitch-enum
 add_flag -Wshadow
 add_flag -Wnon-virtual-dtor
 add_flag -pedantic-errors

--- a/nes/CMakeLists.txt
+++ b/nes/CMakeLists.txt
@@ -5,19 +5,6 @@ add_library(${PROJECT_NAME}
     src/nes.cpp
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME}
-        PRIVATE
-           -Wall
-           -Werror
-           -Wextra
-           -Wswitch-enum
-           -Wshadow
-           -Wnon-virtual-dtor
-           -pedantic-errors
-    )
-endif()
-
 target_compile_features(${PROJECT_NAME}
     PRIVATE
         cxx_std_17

--- a/nes/test/CMakeLists.txt
+++ b/nes/test/CMakeLists.txt
@@ -21,19 +21,6 @@ add_executable(${PROJECT_NAME}
     src/main.cpp
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME}
-        PRIVATE
-           -Wall
-           -Werror
-           -Wextra
-           -Wswitch-enum
-           -Wshadow
-           -Wnon-virtual-dtor
-           -pedantic-errors
-    )
-endif()
-
 target_compile_features(${PROJECT_NAME}
     PRIVATE
         cxx_std_17


### PR DESCRIPTION
This is so that we can easily set up compiler warnings without copy-pasting them everywhere and also allows us to set up separate compiler flags for msvc, gcc, and clang without dirtying our CMakeLists with them.

It also means that if someone wants to build n_e_s and have a newer compiler than us, they won't fail because we've enforced -Werror on a CMakeLists-level.