### PR TITLE
Add ADC for immediate, absolute and zeropage addressing modes

### DIFF
--- a/core/src/mos6502.h
+++ b/core/src/mos6502.h
@@ -62,9 +62,16 @@ private:
     // sets the N flag if bit 7 of the byte is set
     void set_negative(uint8_t byte);
 
+    // sets the V flag based on the original value in the register,
+    // the operand, and temporary resulting value.
+    void set_overflow(uint8_t reg_value,
+            uint8_t operand,
+            uint16_t resulting_value);
+
     // Returns an atom for the cpu pipeline for branching on a condition.
     std::function<void()> branch_on(const std::function<bool()> &condition);
 
+    Pipeline create_add_instruction(Opcode opcode);
     Pipeline create_store_instruction(Opcode opcode);
     Pipeline create_load_instruction(Opcode opcode);
     Pipeline create_zeropage_addressing_steps();

--- a/core/src/opcode.cpp
+++ b/core/src/opcode.cpp
@@ -26,6 +26,12 @@ Opcode decode(const uint8_t op) {
         return {Instruction::BVC, AddressMode::Relative};
     case 0x58:
         return {Instruction::CLI, AddressMode::Implied};
+    case 0x65:
+        return {Instruction::ADC, AddressMode::Zeropage};
+    case 0x69:
+        return {Instruction::ADC, AddressMode::Immediate};
+    case 0x6D:
+        return {Instruction::ADC, AddressMode::Absolute};
     case 0x70:
         return {Instruction::BVS, AddressMode::Relative};
     case 0x78:

--- a/core/src/opcode.h
+++ b/core/src/opcode.h
@@ -29,6 +29,7 @@ enum class Instruction {
     JMP,
     BVC,
     CLI,
+    ADC,
     BVS,
     SEI,
     STY,


### PR DESCRIPTION
Part of #80 
Missing the following addressing modes but I will create a new pull request with those once this one is merged:
Absolute,X
Absolute,Y
Zeropage,X
Indirect-indexed

