### PR TITLE
Add readability-identifier-naming check to clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: '
   modernize-*,
   performance-*,
   readability-else-after-return,
+  readability-identifier-naming,
   readability-non-const-parameter'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
@@ -22,5 +23,58 @@ CheckOptions:
     value:           '16'
   - key:             modernize-loop-convert.NamingStyle
     value:           CamelCase
+
+# readability-identifier-naming
+# Classes, structs, ...
+  - key:    readability-identifier-naming.NamespaceCase
+    value:  lower_case
+  - key:    readability-identifier-naming.ClassCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.StructCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.EnumCase
+    value:  CamelCase
+
+# Variables, member variables, ...
+  - key:    readability-identifier-naming.ParameterCase
+    value:  lower_case
+  - key:    readability-identifier-naming.VariableCase
+    value:  lower_case
+  - key:    readability-identifier-naming.MemberCase
+    value:  lower_case
+  - key:    readability-identifier-naming.PrivateMemberCase
+    value:  lower_case
+  - key:    readability-identifier-naming.PrivateMemberSuffix
+    value:  _
+
+# Functions, methods, ...
+  - key:    readability-identifier-naming.FunctionCase
+    value:  lower_case
+  - key:    readability-identifier-naming.MethodCase
+    value:  lower_case
+
+# Constants
+  - key:    readability-identifier-naming.ConstantPrefix
+    value:  k
+  - key:    readability-identifier-naming.ConstantCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.ConstantMemberSuffix
+    value:  _
+  - key:    readability-identifier-naming.ConstantMemberCase
+    value:  lower_case
+  - key:    readability-identifier-naming.ConstantParameterPrefix
+    value:  ''
+  - key:    readability-identifier-naming.ConstantParameterCase
+    value:  lower_case
+  - key:    readability-identifier-naming.EnumConstantCase
+    value:  aNy_CasE
+  - key:    readability-identifier-naming.LocalConstantParameterPrefix
+    value:  ''
+  - key:    readability-identifier-naming.LocalConstantCase
+    value:  lower_case
+  - key:    readability-identifier-naming.ConstexprVariablePrefix
+    value:  k
+  - key:    readability-identifier-naming.ConstexprVariableCase
+    value:  CamelCase
 ...
 

--- a/core/include/core/icpu.h
+++ b/core/include/core/icpu.h
@@ -4,14 +4,16 @@
 
 namespace n_e_s::core {
 
-const uint8_t C_FLAG = 1 << 0; // carry
-const uint8_t Z_FLAG = 1 << 1; // zero
-const uint8_t I_FLAG = 1 << 2; // interrupt disable
-const uint8_t D_FLAG = 1 << 3; // decimal mode
-const uint8_t B_FLAG = 1 << 4; // break
-const uint8_t FLAG_5 = 1 << 5; // unused, always 1
-const uint8_t V_FLAG = 1 << 6; // overflow
-const uint8_t N_FLAG = 1 << 7; // negative
+enum CpuFlag {
+    C_FLAG = 1 << 0, // carry
+    Z_FLAG = 1 << 1, // zero
+    I_FLAG = 1 << 2, // interrupt disable
+    D_FLAG = 1 << 3, // decimal mode
+    B_FLAG = 1 << 4, // break
+    FLAG_5 = 1 << 5, // unused, always 1
+    V_FLAG = 1 << 6, // overflow
+    N_FLAG = 1 << 7, // negative
+};
 
 class ICpu {
 public:

--- a/core/src/ppu.cpp
+++ b/core/src/ppu.cpp
@@ -86,7 +86,7 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
             registers_->write_toggle = true;
         }
     } else if (addr == kPpuData) {
-        if (registers_->vram_addr < VRAM_SIZE) {
+        if (registers_->vram_addr < kVramSize) {
             ppu_vram_[registers_->vram_addr] = byte;
             registers_->vram_addr += get_vram_address_increment();
         } else {

--- a/core/src/ppu.h
+++ b/core/src/ppu.h
@@ -21,15 +21,15 @@ private:
     uint16_t cycle_;
 
     // Object Atribute Memory
-    constexpr static uint16_t OAM_SIZE{256};
-    uint8_t oam_data_[OAM_SIZE]{};
+    constexpr static uint16_t kOamSize{256};
+    uint8_t oam_data_[kOamSize]{};
 
     // PPU vram. The size of this memory bank shall only be 2kB, but for now
     // we let it fill the whole address space which the PPU has. This should be
     // changed once we have support for letting the cartridge map stuff in this
     // address space.
-    constexpr static uint16_t VRAM_SIZE{6 * 1024};
-    uint8_t ppu_vram_[VRAM_SIZE]{};
+    constexpr static uint16_t kVramSize{6 * 1024};
+    uint8_t ppu_vram_[kVramSize]{};
 
     // Updates cycle and scanline counters
     void update_counters();

--- a/core/src/rom/nrom.cpp
+++ b/core/src/rom/nrom.cpp
@@ -22,23 +22,23 @@ Nrom::Nrom(const INesHeader &h,
 
 // The cartridge owns all space from 0x6000 to 0xFFFF.
 bool Nrom::is_address_in_range(uint16_t addr) const {
-    return addr >= prg_ram_start_;
+    return addr >= kPrgRamStart;
 }
 
 uint8_t Nrom::read_byte(uint16_t addr) const {
-    assert(addr >= prg_ram_start_);
+    assert(addr >= kPrgRamStart);
 
     const std::vector<uint8_t> &memory = translate_address(addr);
-    addr -= addr <= prg_ram_end_ ? prg_ram_start_ : prg_rom_start_;
+    addr -= addr <= kPrgRamEnd ? kPrgRamStart : kPrgRomStart;
 
     return memory[addr % memory.size()];
 }
 
 void Nrom::write_byte(uint16_t addr, uint8_t byte) {
-    assert(addr >= prg_ram_start_);
+    assert(addr >= kPrgRamStart);
 
     std::vector<uint8_t> &memory = translate_address(addr);
-    addr -= addr <= prg_ram_end_ ? prg_ram_start_ : prg_rom_start_;
+    addr -= addr <= kPrgRamEnd ? kPrgRamStart : kPrgRomStart;
 
     memory[addr % memory.size()] = byte;
 }
@@ -49,7 +49,7 @@ std::vector<uint8_t> &Nrom::translate_address(uint16_t addr) {
 }
 
 const std::vector<uint8_t> &Nrom::translate_address(uint16_t addr) const {
-    if (addr <= prg_ram_end_) {
+    if (addr <= kPrgRamEnd) {
         return prg_ram_;
     }
 

--- a/core/src/rom/nrom.h
+++ b/core/src/rom/nrom.h
@@ -24,9 +24,9 @@ private:
     std::vector<uint8_t> chr_rom_; // const?
     std::vector<uint8_t> prg_ram_;
 
-    constexpr static uint16_t prg_ram_start_{0x6000};
-    constexpr static uint16_t prg_ram_end_{0x7FFF};
-    constexpr static uint16_t prg_rom_start_{0x8000};
+    constexpr static uint16_t kPrgRamStart{0x6000};
+    constexpr static uint16_t kPrgRamEnd{0x7FFF};
+    constexpr static uint16_t kPrgRomStart{0x8000};
 };
 
 } // namespace n_e_s::core

--- a/core/test/src/fake_mmu.h
+++ b/core/test/src/fake_mmu.h
@@ -37,6 +37,7 @@ public:
         write_byte(addr + 1, upper);
     }
 
+private:
     std::map<uint16_t, uint8_t> memory_;
 };
 

--- a/core/test/src/hexprinter.h
+++ b/core/test/src/hexprinter.h
@@ -9,21 +9,21 @@
 
 namespace n_e_s::core::test {
 
-constexpr int HEX_DIGIT_BITS = 4;
+constexpr int kHexDigitBits = 4;
 
 template <typename T>
-struct is_char : std::integral_constant<bool,
-                         std::is_same<T, char>::value ||
-                                 std::is_same<T, signed char>::value ||
-                                 std::is_same<T, unsigned char>::value> {};
+struct IsChar : std::integral_constant<bool,
+                        std::is_same<T, char>::value ||
+                                std::is_same<T, signed char>::value ||
+                                std::is_same<T, unsigned char>::value> {};
 
 // Adapted from https://stackoverflow.com/a/35963334
 template <typename T>
 std::string hex_out_s(T val) {
     std::stringstream sformatter;
     sformatter << std::hex << std::internal << "0x" << std::setfill('0')
-               << std::setw(sizeof(T) * CHAR_BIT / HEX_DIGIT_BITS)
-               << (is_char<T>::value ? static_cast<int>(val) : val);
+               << std::setw(sizeof(T) * CHAR_BIT / kHexDigitBits)
+               << (IsChar<T>::value ? static_cast<int>(val) : val);
 
     return sformatter.str();
 }

--- a/core/test/src/icpu_helpers.cpp
+++ b/core/test/src/icpu_helpers.cpp
@@ -13,6 +13,8 @@ bool operator==(const ICpu::Registers &a, const ICpu::Registers &b) {
            a.y == b.y && a.p == b.p;
 }
 
+// Required by gtest to use pascal case.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void PrintTo(const ICpu::Registers &r, std::ostream *os) {
     *os << "PC: " << hex_out_s(r.pc);
     *os << " SP: " << hex_out_s(r.sp);

--- a/core/test/src/icpu_helpers.h
+++ b/core/test/src/icpu_helpers.h
@@ -8,6 +8,8 @@ namespace n_e_s::core {
 
 bool operator==(const ICpu::Registers &a, const ICpu::Registers &b);
 
+// Required by gtest to use pascal case.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void PrintTo(const ICpu::Registers &r, std::ostream *os);
 
 } // namespace n_e_s::core


### PR DESCRIPTION
What do you think about this check? Some more changes to the style is needed to adapt it completely to our style