### PR TITLE
Warn if an instruction family isn't handled in CPU

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -297,7 +297,6 @@ Pipeline Mos6502::parse_next_instruction() {
         result.push([=]() { set_flag(D_FLAG); });
         break;
     case Instruction::Invalid:
-    default:
         std::stringstream err;
         err << "Bad instruction: " << std::showbase << std::hex << +raw_opcode;
         throw std::logic_error(err.str());


### PR DESCRIPTION
Using default when all cases should be covered can hide a warning, and the default case will only ever be hit in the case of undefined behaviour if you're switching on an enum and all cases are covered.