### PR TITLE
Increase pc only once in PHA and PHP

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -93,7 +93,9 @@ Pipeline Mos6502::parse_next_instruction() {
         result.push([=]() { registers_->pc = mmu_->read_word(kBrkAddress); });
         break;
     case Instruction::PHP:
-        result.push([=]() { ++registers_->pc; });
+        result.push([=]() {
+            /* Do nothing. */
+        });
         result.push([=]() { stack_.push_byte(registers_->p); });
         break;
     case Instruction::BPL:
@@ -149,7 +151,9 @@ Pipeline Mos6502::parse_next_instruction() {
         }
         break;
     case Instruction::PHA:
-        result.push([=]() { ++registers_->pc; });
+        result.push([=]() {
+            /* Do nothing. */
+        });
         result.push([=]() { stack_.push_byte(registers_->a); });
         break;
     case Instruction::JMP:

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -473,7 +473,6 @@ TEST_F(CpuTest, php) {
 
     expected.sp = 0x09;
     expected.p = registers.p;
-    ++expected.pc;
 
     EXPECT_CALL(mmu, write_byte(kStackOffset + registers.sp, registers.p));
 
@@ -692,11 +691,10 @@ TEST_F(CpuTest, pha) {
 
     EXPECT_CALL(mmu, write_byte(kStackOffset + registers.sp, registers.a));
 
-    step_execution(3);
-
-    ++expected.pc;
     expected.sp = 0x04;
     expected.a = registers.a;
+
+    step_execution(3);
 
     EXPECT_EQ(expected, registers);
 }


### PR DESCRIPTION
Looks like PC should only be increased once for these instructions.

```
PHA, PHP
        #  address R/W description
       --- ------- --- -----------------------------------------------
        1    PC     R  fetch opcode, increment PC
        2    PC     R  read next instruction byte (and throw it away)
        3  $0100,S  W  push register on stack, decrement S
```
The second step is just a fake read, the PC is never incremented. We increase the PC in parse_next_instruction so it does not need to be done again.