### PR TITLE
Run the application for 10 million cycles instead of 9000

### DIFF
--- a/application/src/main.cpp
+++ b/application/src/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
     Nes nes;
     nes.load_rom(argv[1]);
 
-    for (uint32_t i = 0; i < 9000; ++i) {
+    for (uint32_t i = 0; i < 10'000'000; ++i) {
         nes.execute();
     }
 


### PR DESCRIPTION
This is helpful because otherwise the PPU doesn't have time to "boot up" and the CPU won't start loading new instructions that we may or may not have implemented yet.