### PR TITLE
Update pipeline to allow skipping of steps

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -426,9 +426,9 @@ Pipeline Mos6502::create_branch_instruction(
     result.push_conditional([=]() {
         if (!condition()) {
             ++registers_->pc;
-            return false;
+            return StepResult::Stop;
         }
-        return true;
+        return StepResult::Continue;
     });
 
     result.push_conditional([=]() {
@@ -438,10 +438,10 @@ Pipeline Mos6502::create_branch_instruction(
         registers_->pc += to_signed(offset);
 
         if (page != high_byte(registers_->pc)) {
-            return true;
+            return StepResult::Continue;
             // We crossed a page boundary so we spend 1 more cycle.
         }
-        return false;
+        return StepResult::Stop;
     });
 
     result.push([=]() { /* Do nothing. */ });

--- a/core/src/pipeline.cpp
+++ b/core/src/pipeline.cpp
@@ -5,7 +5,7 @@ namespace n_e_s::core {
 void Pipeline::push(const StepT &step) {
     steps_.emplace_back([=]() {
         step();
-        return true;
+        return StepResult::Continue;
     });
 }
 
@@ -31,8 +31,16 @@ void Pipeline::clear() {
 }
 
 void Pipeline::execute_step() {
-    continue_ = steps_.front()();
-    steps_.pop_front();
+    if (!steps_.empty()) {
+        const StepResult res = steps_.front()();
+        steps_.pop_front();
+
+        continue_ = res != StepResult::Stop;
+
+        if (res == StepResult::Skip) {
+            execute_step();
+        }
+    }
 }
 
 } // namespace n_e_s::core

--- a/core/src/pipeline.h
+++ b/core/src/pipeline.h
@@ -5,18 +5,24 @@
 
 namespace n_e_s::core {
 
+enum class StepResult { Continue, Skip, Stop };
+
 class Pipeline {
     using StepT = std::function<void()>;
-    using ConditionalStepT = std::function<bool()>;
+    using ConditionalStepT = std::function<StepResult()>;
 
 public:
     // Pushes a step to this pipeline. The step will always be executed as long
     // as the step before was executed.
     void push(const StepT &step);
 
-    // Pushes a step to this pipeline. If the step returns false, then this
-    // pipeline will be considered done and any remaining steps will not be
-    // exectued.
+    // Pushes a step to this pipeline.
+    // If the step returns Stop, then this pipeline will be considered
+    // done and any remaining steps will not be exectued.
+    // If the step returns Continue, then the following step will be run the
+    // next time this pipeline is executed.
+    // If the step returns Skip, then the followinge step will be run
+    // directly.
     void push_conditional(ConditionalStepT step);
 
     // Pushes all steps in another pipeline to this pipeline.


### PR DESCRIPTION
This will simplify implementation of addressing modes with conditional steps. For example absolute indexed addressing:
>         1     PC      R  fetch opcode, increment PC
>         2     PC      R  fetch low byte of address, increment PC
>         3     PC      R  fetch high byte of address,
>                          add index register to low address byte,
>                          increment PC
>         4  address+I* R  read from effective address,
>                          fix the high byte of effective address
>         5+ address+I  R  re-read from effective address
>  Notes: I denotes either index register (X or Y).
>               * The high byte of the effective address may be invalid
>                 at this time, i.e. it may be smaller by $100.
> 
>               + This cycle will be executed only if the effective address
>                 was invalid during cycle #4, i.e. page boundary was crossed.

Step 4 can be marked as skipped if a page boundary is not crossed to run step 5 directly where the actual instruction logic can be put.