### PR TITLE
Print where we encountered the bad instruction

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -80,6 +80,7 @@ Pipeline Mos6502::parse_next_instruction() {
     if (opcode.family == Family::Invalid) {
         std::stringstream err;
         err << "Bad instruction: " << std::showbase << std::hex << +raw_opcode;
+        err << " @ " << registers_->pc - 1;
         throw std::logic_error(err.str());
     }
 


### PR DESCRIPTION
This is nice to get an idea of how far through the rom we got before things broke.
```
terminate called after throwing an instance of 'std::logic_error'
  what():  Bad instruction: 0xbd @ 0xc027
```