### PR TITLE
Fail if test coverage is less than 99%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - CXX=g++-7 CXXFLAGS="-fprofile-arcs -ftest-coverage" cmake ..
         - make
         - ctest --output-on-failure
-        - gcovr -p --root .. --fail-under-line=95 --exclude '_deps/' --exclude '(.+/)?test/'
+        - gcovr -p --root .. --fail-under-line=99 --exclude '_deps/' --exclude '(.+/)?test/'
 
     - name: "gcc 8"
       addons: &gcc8


### PR DESCRIPTION
We've been at 99% code coverage for a long time now and the code base is getting quite big, so this probably won't change much.