### PR TITLE
Fix unsupported mapper code not being tested

### DIFF
--- a/core/test/src/test_rom.cpp
+++ b/core/test/src/test_rom.cpp
@@ -57,7 +57,7 @@ TEST(RomFactory, doesnt_parse_bytes_without_a_nes_header) {
 }
 
 TEST(RomFactory, fails_if_mapper_not_supported) {
-    std::string bytes{ines_header_bytes(0xCD, 1, 1, 1)};
+    std::string bytes{ines_header_bytes(0xCD, 0, 0, 0)};
     std::stringstream ss(bytes);
     EXPECT_THROW(RomFactory::from_bytes(ss), std::logic_error);
 }


### PR DESCRIPTION
This was triggering a different error condition before (incorrect rom size). To check that this PR worked, you can check the test coverage travis job and make sure that it tests the mapper being wrong now.