### PR TITLE
Add more gcc flags

### DIFF
--- a/warnings/CMakeLists.txt
+++ b/warnings/CMakeLists.txt
@@ -14,13 +14,25 @@ target_compile_options(${PROJECT_NAME} INTERFACE
     $<$<OR:$<BOOL:${CLANG}>,$<CXX_COMPILER_ID:GNU>>:
         -pedantic-errors;
         -Wall;
+        -Wdouble-promotion;
+        -Wduplicated-cond;
         -Werror;
         -Wextra;
+        -Wformat=2;
+        -Wlogical-op;
         -Wnon-virtual-dtor;
+        -Wnull-dereference;
+        -Wold-style-cast;
         -Wshadow;
     >
     $<$<OR:$<BOOL:${CLANGCL}>,$<CXX_COMPILER_ID:MSVC>>:
         /permissive-;
         /WX;
+    >
+)
+
+target_compile_options(${PROJECT_NAME} INTERFACE
+    $<$<BOOL:${CLANG}>:
+      -Wno-unknown-warning-option;
     >
 )


### PR DESCRIPTION
Taken from: https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html

~~Some warnings can unfortunately not be enabled since they also affect gmock. We should see if we can change how we enable flags to only set on our own code.~~ Not true anymore after #127 
