### PR TITLE
Use EXPECT_CALL instead of ON_CALL for read_byte

### DIFF
--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -125,8 +125,7 @@ public:
 
     void stage_instruction(uint8_t instruction) {
         expected.pc += 1;
-        EXPECT_CALL(mmu, read_byte(registers.pc))
-                .WillRepeatedly(Return(instruction));
+        EXPECT_CALL(mmu, read_byte(registers.pc)).WillOnce(Return(instruction));
     }
 
     void step_execution(uint8_t cycles) {
@@ -141,8 +140,7 @@ public:
         expected.p = registers.p = branch_flag;
         expected.pc = registers.pc + 2 + offset;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(offset));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(offset));
 
         step_execution(expected_cycles);
         EXPECT_EQ(expected, registers);
@@ -207,8 +205,7 @@ public:
         *reg = 42;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -219,8 +216,7 @@ public:
         expected.p |= N_FLAG;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -231,8 +227,7 @@ public:
         *reg = 127;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -243,8 +238,7 @@ public:
         expected.p |= Z_FLAG;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -255,8 +249,7 @@ public:
         *reg = 1;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -267,7 +260,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -279,7 +272,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -291,7 +284,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -303,7 +296,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -315,7 +308,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -329,8 +322,8 @@ public:
         *target_reg = 0x42;
         expected.pc += 1;
 
-        EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
-        EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x42));
+        EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
+        EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0x42));
 
         step_execution(3);
         EXPECT_EQ(expected, registers);
@@ -348,9 +341,9 @@ public:
         *target_reg = 0x42;
         expected.pc += 1;
 
-        EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+        EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
         EXPECT_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED)))
-                .WillRepeatedly(Return(0x42));
+                .WillOnce(Return(0x42));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -364,7 +357,7 @@ public:
         ++expected.pc;
 
         EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(0b00001000));
+                .WillOnce(Return(0b00001000));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -377,8 +370,7 @@ public:
         registers.p |= Z_FLAG | N_FLAG;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(0xFA));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0xFA));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -391,8 +383,7 @@ public:
         registers.p |= N_FLAG;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(42));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(42));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -404,8 +395,7 @@ public:
         registers.p |= Z_FLAG;
         ++expected.pc;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(127));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(127));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -418,7 +408,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(127));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(127));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -434,7 +424,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x5678));
-        EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillRepeatedly(Return(0x07));
+        EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillOnce(Return(0x07));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -451,8 +441,8 @@ public:
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x5678));
         EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
-                .WillRepeatedly(Return(0xDEAD));
-        EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillRepeatedly(Return(0x07));
+                .WillOnce(Return(0xDEAD));
+        EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillOnce(Return(0x07));
 
         step_execution(5);
         EXPECT_EQ(expected, registers);
@@ -464,9 +454,8 @@ public:
         registers.p |= Z_FLAG;
         expected.pc += 1;
 
-        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-                .WillRepeatedly(Return(0x44));
-        EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(127));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x44));
+        EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(127));
 
         step_execution(3);
         EXPECT_EQ(expected, registers);
@@ -485,7 +474,7 @@ public:
         *target_reg = 0x37;
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x0100));
         EXPECT_CALL(mmu, read_byte(0x0100 + *index_reg))
-                .WillRepeatedly(Return(*target_reg));
+                .WillOnce(Return(*target_reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -508,7 +497,7 @@ public:
             InSequence s;
             EXPECT_CALL(mmu, read_byte(0x00FF + *index_reg));
             EXPECT_CALL(mmu, read_byte(0x01FF + *index_reg))
-                    .WillRepeatedly(Return(*target_reg));
+                    .WillOnce(Return(*target_reg));
             step_execution(5);
         }
 
@@ -528,7 +517,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x0100));
-        EXPECT_CALL(mmu, read_byte(0x0100 + 0x42)).WillRepeatedly(Return(0));
+        EXPECT_CALL(mmu, read_byte(0x0100 + 0x42)).WillOnce(Return(0));
 
         *target_reg = 0;
 
@@ -549,7 +538,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x0100));
-        EXPECT_CALL(mmu, read_byte(0x0100 + 0x42)).WillRepeatedly(Return(230));
+        EXPECT_CALL(mmu, read_byte(0x0100 + 0x42)).WillOnce(Return(230));
 
         *target_reg = 230;
 
@@ -670,8 +659,7 @@ TEST_F(CpuTest, and_imm) {
     ++expected.pc;
     expected.a = 0b00001010;
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1))
-            .WillRepeatedly(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0b00001111));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -689,7 +677,7 @@ TEST_F(CpuTest, and_abs_sets_zero_clears_neg) {
     expected.p = Z_FLAG;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    EXPECT_CALL(mmu, read_byte(0x5678)).WillRepeatedly(Return(0b01010101));
+    EXPECT_CALL(mmu, read_byte(0x5678)).WillOnce(Return(0b01010101));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -707,7 +695,7 @@ TEST_F(CpuTest, and_abs_sets_neg_clears_zero) {
     expected.p = N_FLAG;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    EXPECT_CALL(mmu, read_byte(0x5678)).WillRepeatedly(Return(0b11110001));
+    EXPECT_CALL(mmu, read_byte(0x5678)).WillOnce(Return(0b11110001));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -725,8 +713,7 @@ TEST_F(CpuTest, and_absx_without_page_crossing) {
     expected.a = 0b00001010;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10))
-            .WillRepeatedly(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillOnce(Return(0b00001111));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -745,9 +732,8 @@ TEST_F(CpuTest, and_absx_with_page_crossing) {
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
     EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
-            .WillRepeatedly(Return(0xDEAD));
-    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB))
-            .WillRepeatedly(Return(0b00001111));
+            .WillOnce(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillOnce(Return(0b00001111));
 
     step_execution(5);
     EXPECT_EQ(expected, registers);
@@ -765,8 +751,7 @@ TEST_F(CpuTest, and_absy_without_page_crossing) {
     expected.a = 0b00001010;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10))
-            .WillRepeatedly(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillOnce(Return(0b00001111));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -781,8 +766,8 @@ TEST_F(CpuTest, bit_zero_sets_zero) {
     expected.pc += 1;
     expected.p = Z_FLAG;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x12));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0x12));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -797,8 +782,8 @@ TEST_F(CpuTest, bit_zero_sets_negative) {
     expected.pc += 1;
     expected.p = N_FLAG;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0xA3));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0xA3));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -813,8 +798,8 @@ TEST_F(CpuTest, bit_zero_sets_overflow) {
     expected.pc += 1;
     expected.p = V_FLAG;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x53));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0x53));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -830,7 +815,7 @@ TEST_F(CpuTest, bit_abs_sets_negative_and_overflow) {
     expected.p = V_FLAG | N_FLAG;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    EXPECT_CALL(mmu, read_byte(0x5678)).WillRepeatedly(Return(0xC3));
+    EXPECT_CALL(mmu, read_byte(0x5678)).WillOnce(Return(0xC3));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -845,7 +830,7 @@ TEST_F(CpuTest, plp) {
     expected.p = 0x12;
 
     EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
-            .WillRepeatedly(Return(0x12));
+            .WillOnce(Return(0x12));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1025,7 +1010,7 @@ TEST_F(CpuTest, adc_imm_no_carry_or_overflow) {
     expected.a = 0x60;
     ++expected.pc;
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x10));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x10));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1040,7 +1025,7 @@ TEST_F(CpuTest, adc_imm_carry_but_no_overflow) {
     expected.a = 0x20;
     ++expected.pc;
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x50));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x50));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1054,7 +1039,7 @@ TEST_F(CpuTest, adc_imm_no_carry_but_overflow) {
     expected.a = 0xA0;
     ++expected.pc;
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x50));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x50));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1068,7 +1053,7 @@ TEST_F(CpuTest, adc_imm_carry_and_overflow) {
     expected.a = 0x60;
     ++expected.pc;
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x90));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x90));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1083,7 +1068,7 @@ TEST_F(CpuTest, adc_abs_no_carry_or_overflow) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-    EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(0x10));
+    EXPECT_CALL(mmu, read_byte(0x4567)).WillOnce(Return(0x10));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1099,8 +1084,8 @@ TEST_F(CpuTest, adc_zero_no_carry_or_overflow) {
     expected.a = 0x60;
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x45));
-    EXPECT_CALL(mmu, read_byte(0x45)).WillRepeatedly(Return(0x10));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x45));
+    EXPECT_CALL(mmu, read_byte(0x45)).WillOnce(Return(0x10));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -1118,7 +1103,7 @@ TEST_F(CpuTest, adc_absx_no_carry_or_overflow_no_pagecrossing) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillRepeatedly(Return(0x21));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillOnce(Return(0x21));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1137,8 +1122,8 @@ TEST_F(CpuTest, adc_absy_no_carry_or_overflow_with_pagecrossing) {
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
     EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
-            .WillRepeatedly(Return(0xDEAD));
-    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillRepeatedly(Return(0x21));
+            .WillOnce(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillOnce(Return(0x21));
 
     step_execution(5);
     EXPECT_EQ(expected, registers);
@@ -1155,7 +1140,7 @@ TEST_F(CpuTest, pla_sets_z_clears_n) {
     expected.p = Z_FLAG;
 
     EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
-            .WillRepeatedly(Return(0x00));
+            .WillOnce(Return(0x00));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1172,7 +1157,7 @@ TEST_F(CpuTest, pla_sets_n_clears_z) {
     expected.p = N_FLAG;
 
     EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
-            .WillRepeatedly(Return(0x92));
+            .WillOnce(Return(0x92));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1668,9 +1653,8 @@ TEST_F(CpuTest, cmp_zero_x_sets_zc) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED)))
-            .WillRepeatedly(Return(0x07));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED))).WillOnce(Return(0x07));
 
     step_execution(4);
 
@@ -1718,8 +1702,8 @@ TEST_F(CpuTest, inc_zero_increments) {
     registers.pc = 0x1234;
     stage_instruction(INC_ZERO);
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x05));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0x05));
 
     {
         InSequence s;
@@ -1733,8 +1717,8 @@ TEST_F(CpuTest, inc_zero_sets_z_flag) {
     expected.p |= Z_FLAG;
     stage_instruction(INC_ZERO);
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0xFF));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0xFF));
     step_execution(5);
 }
 TEST_F(CpuTest, inc_zero_clears_z_flag) {
@@ -1742,8 +1726,8 @@ TEST_F(CpuTest, inc_zero_clears_z_flag) {
     registers.p |= Z_FLAG;
     stage_instruction(INC_ZERO);
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0xFD));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(0xFD));
     step_execution(5);
 }
 TEST_F(CpuTest, inc_zero_sets_n_flag) {
@@ -1751,8 +1735,8 @@ TEST_F(CpuTest, inc_zero_sets_n_flag) {
     expected.p |= N_FLAG;
     stage_instruction(INC_ZERO);
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(127));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(127));
     step_execution(5);
 }
 TEST_F(CpuTest, inc_zero_clears_n_flag) {
@@ -1760,8 +1744,8 @@ TEST_F(CpuTest, inc_zero_clears_n_flag) {
     registers.p |= N_FLAG;
     stage_instruction(INC_ZERO);
 
-    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
-    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(125));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillOnce(Return(125));
     step_execution(5);
 }
 
@@ -1907,7 +1891,7 @@ TEST_F(CpuTest, sta_zero_x_indexed) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
     EXPECT_CALL(mmu, write_byte(u16_to_u8(0x44 + 0xED), 0x07));
 
     step_execution(4);
@@ -1939,7 +1923,7 @@ TEST_F(CpuTest, stx_zero) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
     EXPECT_CALL(mmu, write_byte(0x44, 0x07));
 
     step_execution(3);
@@ -1956,7 +1940,7 @@ TEST_F(CpuTest, stx_zero_y_indexed) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
     EXPECT_CALL(mmu, write_byte(u16_to_u8(0x44 + 0xED), 0x07));
 
     step_execution(4);
@@ -2017,7 +2001,7 @@ TEST_F(CpuTest, sta_indexed_indirect) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0xAB));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0xAB));
     ON_CALL(mmu, read_word(u16_to_u8(0xAB + 0xED)))
             .WillByDefault(Return(0x1234));
     EXPECT_CALL(mmu, write_byte(0x1234, 0x07));
@@ -2036,9 +2020,9 @@ TEST_F(CpuTest, sta_indexed_indirect_handles_wraparound) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0xFF));
-    EXPECT_CALL(mmu, read_byte(0xFF)).WillRepeatedly(Return(0x34));
-    EXPECT_CALL(mmu, read_byte(0x00)).WillRepeatedly(Return(0x12));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0xFF));
+    EXPECT_CALL(mmu, read_byte(0xFF)).WillOnce(Return(0x34));
+    EXPECT_CALL(mmu, read_byte(0x00)).WillOnce(Return(0x12));
     EXPECT_CALL(mmu, write_byte(0x1234, 0x07));
 
     step_execution(6);
@@ -2055,7 +2039,7 @@ TEST_F(CpuTest, sta_indirect_indexed) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x42));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x42));
     ON_CALL(mmu, read_word(0x42)).WillByDefault(Return(0x1234));
     EXPECT_CALL(mmu, write_byte(0x1234 + 0xED, 0x07));
 
@@ -2099,7 +2083,7 @@ TEST_F(CpuTest, sty_zero) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
     EXPECT_CALL(mmu, write_byte(0x44, 0x07));
 
     step_execution(3);
@@ -2116,7 +2100,7 @@ TEST_F(CpuTest, sty_zero_x_indexed) {
 
     expected.pc += 1;
 
-    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
     EXPECT_CALL(mmu, write_byte(u16_to_u8(0x44 + 0xED), 0x07));
 
     step_execution(4);

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -125,8 +125,8 @@ public:
 
     void stage_instruction(uint8_t instruction) {
         expected.pc += 1;
-        ON_CALL(mmu, read_byte(registers.pc))
-                .WillByDefault(Return(instruction));
+        EXPECT_CALL(mmu, read_byte(registers.pc))
+                .WillRepeatedly(Return(instruction));
     }
 
     void step_execution(uint8_t cycles) {
@@ -141,7 +141,8 @@ public:
         expected.p = registers.p = branch_flag;
         expected.pc = registers.pc + 2 + offset;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(offset));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(offset));
 
         step_execution(expected_cycles);
         EXPECT_EQ(expected, registers);
@@ -206,7 +207,8 @@ public:
         *reg = 42;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -217,7 +219,8 @@ public:
         expected.p |= N_FLAG;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -228,7 +231,8 @@ public:
         *reg = 127;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -239,7 +243,8 @@ public:
         expected.p |= Z_FLAG;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -250,7 +255,8 @@ public:
         *reg = 1;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(*reg));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -261,7 +267,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -273,7 +279,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -285,7 +291,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -297,7 +303,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -309,7 +315,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(*reg));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(*reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -323,8 +329,8 @@ public:
         *target_reg = 0x42;
         expected.pc += 1;
 
-        ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
-        ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0x42));
+        EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+        EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x42));
 
         step_execution(3);
         EXPECT_EQ(expected, registers);
@@ -342,9 +348,9 @@ public:
         *target_reg = 0x42;
         expected.pc += 1;
 
-        ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
-        ON_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED)))
-                .WillByDefault(Return(0x42));
+        EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+        EXPECT_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED)))
+                .WillRepeatedly(Return(0x42));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -357,8 +363,8 @@ public:
         registers.p |= Z_FLAG | C_FLAG;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1))
-                .WillByDefault(Return(0b00001000));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(0b00001000));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -371,7 +377,8 @@ public:
         registers.p |= Z_FLAG | N_FLAG;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0xFA));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(0xFA));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -384,7 +391,8 @@ public:
         registers.p |= N_FLAG;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(42));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(42));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -396,7 +404,8 @@ public:
         registers.p |= Z_FLAG;
         ++expected.pc;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(127));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(127));
 
         step_execution(2);
         EXPECT_EQ(expected, registers);
@@ -409,7 +418,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-        ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(127));
+        EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(127));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -425,7 +434,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x5678));
-        ON_CALL(mmu, read_byte(0x5678 + 0x10)).WillByDefault(Return(0x07));
+        EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillRepeatedly(Return(0x07));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -441,9 +450,9 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x5678));
-        ON_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
-                .WillByDefault(Return(0xDEAD));
-        ON_CALL(mmu, read_byte(0x5678 + 0xAB)).WillByDefault(Return(0x07));
+        EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
+                .WillRepeatedly(Return(0xDEAD));
+        EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillRepeatedly(Return(0x07));
 
         step_execution(5);
         EXPECT_EQ(expected, registers);
@@ -455,8 +464,9 @@ public:
         registers.p |= Z_FLAG;
         expected.pc += 1;
 
-        ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x44));
-        ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(127));
+        EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+                .WillRepeatedly(Return(0x44));
+        EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(127));
 
         step_execution(3);
         EXPECT_EQ(expected, registers);
@@ -474,8 +484,8 @@ public:
 
         *target_reg = 0x37;
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x0100));
-        ON_CALL(mmu, read_byte(0x0100 + *index_reg))
-                .WillByDefault(Return(*target_reg));
+        EXPECT_CALL(mmu, read_byte(0x0100 + *index_reg))
+                .WillRepeatedly(Return(*target_reg));
 
         step_execution(4);
         EXPECT_EQ(expected, registers);
@@ -493,8 +503,6 @@ public:
 
         *target_reg = 0x37;
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x01FF));
-
-        EXPECT_CALL(mmu, read_byte(testing::_)).Times(testing::AnyNumber());
 
         {
             InSequence s;
@@ -520,7 +528,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x0100));
-        ON_CALL(mmu, read_byte(0x0100 + 0x42)).WillByDefault(Return(0));
+        EXPECT_CALL(mmu, read_byte(0x0100 + 0x42)).WillRepeatedly(Return(0));
 
         *target_reg = 0;
 
@@ -541,7 +549,7 @@ public:
         expected.pc += 2;
 
         ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x0100));
-        ON_CALL(mmu, read_byte(0x0100 + 0x42)).WillByDefault(Return(230));
+        EXPECT_CALL(mmu, read_byte(0x0100 + 0x42)).WillRepeatedly(Return(230));
 
         *target_reg = 230;
 
@@ -568,11 +576,13 @@ TEST_F(CpuTest, reset) {
 TEST_F(CpuTest, reset_clears_pipeline) {
     stage_instruction(SEC);
     ON_CALL(mmu, read_word(kResetAddress)).WillByDefault(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(0xDEAD)).WillOnce(Return(0x00));
     expected.pc = 0xDEAD + 1;
 
     cpu->execute(); // Stage things for execution.
     cpu->reset();
-    cpu->execute(); // Should read an opcode and not execute what's been staged.
+    cpu->execute(); // Should read an opcode from 0xDEAD and not execute what's
+                    // been staged.
 
     EXPECT_EQ(expected, registers);
 }
@@ -660,7 +670,8 @@ TEST_F(CpuTest, and_imm) {
     ++expected.pc;
     expected.a = 0b00001010;
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1))
+            .WillRepeatedly(Return(0b00001111));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -678,7 +689,7 @@ TEST_F(CpuTest, and_abs_sets_zero_clears_neg) {
     expected.p = Z_FLAG;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678)).WillByDefault(Return(0b01010101));
+    EXPECT_CALL(mmu, read_byte(0x5678)).WillRepeatedly(Return(0b01010101));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -696,7 +707,7 @@ TEST_F(CpuTest, and_abs_sets_neg_clears_zero) {
     expected.p = N_FLAG;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678)).WillByDefault(Return(0b11110001));
+    EXPECT_CALL(mmu, read_byte(0x5678)).WillRepeatedly(Return(0b11110001));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -714,7 +725,8 @@ TEST_F(CpuTest, and_absx_without_page_crossing) {
     expected.a = 0b00001010;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678 + 0x10)).WillByDefault(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10))
+            .WillRepeatedly(Return(0b00001111));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -732,9 +744,10 @@ TEST_F(CpuTest, and_absx_with_page_crossing) {
     expected.a = 0b00001010;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
-            .WillByDefault(Return(0xDEAD));
-    ON_CALL(mmu, read_byte(0x5678 + 0xAB)).WillByDefault(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
+            .WillRepeatedly(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB))
+            .WillRepeatedly(Return(0b00001111));
 
     step_execution(5);
     EXPECT_EQ(expected, registers);
@@ -752,7 +765,8 @@ TEST_F(CpuTest, and_absy_without_page_crossing) {
     expected.a = 0b00001010;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678 + 0x10)).WillByDefault(Return(0b00001111));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10))
+            .WillRepeatedly(Return(0b00001111));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -767,8 +781,8 @@ TEST_F(CpuTest, bit_zero_sets_zero) {
     expected.pc += 1;
     expected.p = Z_FLAG;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0x12));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x12));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -783,8 +797,8 @@ TEST_F(CpuTest, bit_zero_sets_negative) {
     expected.pc += 1;
     expected.p = N_FLAG;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0xA3));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0xA3));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -799,8 +813,8 @@ TEST_F(CpuTest, bit_zero_sets_overflow) {
     expected.pc += 1;
     expected.p = V_FLAG;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0x53));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x53));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -816,7 +830,7 @@ TEST_F(CpuTest, bit_abs_sets_negative_and_overflow) {
     expected.p = V_FLAG | N_FLAG;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678)).WillByDefault(Return(0xC3));
+    EXPECT_CALL(mmu, read_byte(0x5678)).WillRepeatedly(Return(0xC3));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -830,8 +844,8 @@ TEST_F(CpuTest, plp) {
     expected.sp = registers.sp + 1u;
     expected.p = 0x12;
 
-    ON_CALL(mmu, read_byte(kStackOffset + expected.sp))
-            .WillByDefault(Return(0x12));
+    EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
+            .WillRepeatedly(Return(0x12));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1011,7 +1025,7 @@ TEST_F(CpuTest, adc_imm_no_carry_or_overflow) {
     expected.a = 0x60;
     ++expected.pc;
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x10));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x10));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1026,7 +1040,7 @@ TEST_F(CpuTest, adc_imm_carry_but_no_overflow) {
     expected.a = 0x20;
     ++expected.pc;
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x50));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x50));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1040,7 +1054,7 @@ TEST_F(CpuTest, adc_imm_no_carry_but_overflow) {
     expected.a = 0xA0;
     ++expected.pc;
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x50));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x50));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1054,7 +1068,7 @@ TEST_F(CpuTest, adc_imm_carry_and_overflow) {
     expected.a = 0x60;
     ++expected.pc;
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x90));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x90));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1069,7 +1083,7 @@ TEST_F(CpuTest, adc_abs_no_carry_or_overflow) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(registers.pc + 1)).WillByDefault(Return(0x4567));
-    ON_CALL(mmu, read_byte(0x4567)).WillByDefault(Return(0x10));
+    EXPECT_CALL(mmu, read_byte(0x4567)).WillRepeatedly(Return(0x10));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1085,8 +1099,8 @@ TEST_F(CpuTest, adc_zero_no_carry_or_overflow) {
     expected.a = 0x60;
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x45));
-    ON_CALL(mmu, read_byte(0x45)).WillByDefault(Return(0x10));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x45));
+    EXPECT_CALL(mmu, read_byte(0x45)).WillRepeatedly(Return(0x10));
 
     step_execution(3);
     EXPECT_EQ(expected, registers);
@@ -1104,7 +1118,7 @@ TEST_F(CpuTest, adc_absx_no_carry_or_overflow_no_pagecrossing) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678 + 0x10)).WillByDefault(Return(0x21));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0x10)).WillRepeatedly(Return(0x21));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1122,9 +1136,9 @@ TEST_F(CpuTest, adc_absy_no_carry_or_overflow_with_pagecrossing) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x5678));
-    ON_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
-            .WillByDefault(Return(0xDEAD));
-    ON_CALL(mmu, read_byte(0x5678 + 0xAB)).WillByDefault(Return(0x21));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB - 0x0100))
+            .WillRepeatedly(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(0x5678 + 0xAB)).WillRepeatedly(Return(0x21));
 
     step_execution(5);
     EXPECT_EQ(expected, registers);
@@ -1140,8 +1154,8 @@ TEST_F(CpuTest, pla_sets_z_clears_n) {
     expected.a = 0x00;
     expected.p = Z_FLAG;
 
-    ON_CALL(mmu, read_byte(kStackOffset + expected.sp))
-            .WillByDefault(Return(0x00));
+    EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
+            .WillRepeatedly(Return(0x00));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1157,8 +1171,8 @@ TEST_F(CpuTest, pla_sets_n_clears_z) {
     expected.a = 0x92;
     expected.p = N_FLAG;
 
-    ON_CALL(mmu, read_byte(kStackOffset + expected.sp))
-            .WillByDefault(Return(0x92));
+    EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
+            .WillRepeatedly(Return(0x92));
 
     step_execution(4);
     EXPECT_EQ(expected, registers);
@@ -1654,8 +1668,9 @@ TEST_F(CpuTest, cmp_zero_x_sets_zc) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED))).WillByDefault(Return(0x07));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(u16_to_u8(0x44 + 0xED)))
+            .WillRepeatedly(Return(0x07));
 
     step_execution(4);
 
@@ -1703,8 +1718,8 @@ TEST_F(CpuTest, inc_zero_increments) {
     registers.pc = 0x1234;
     stage_instruction(INC_ZERO);
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0x05));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0x05));
 
     {
         InSequence s;
@@ -1718,8 +1733,8 @@ TEST_F(CpuTest, inc_zero_sets_z_flag) {
     expected.p |= Z_FLAG;
     stage_instruction(INC_ZERO);
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0xFF));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0xFF));
     step_execution(5);
 }
 TEST_F(CpuTest, inc_zero_clears_z_flag) {
@@ -1727,8 +1742,8 @@ TEST_F(CpuTest, inc_zero_clears_z_flag) {
     registers.p |= Z_FLAG;
     stage_instruction(INC_ZERO);
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(0xFD));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(0xFD));
     step_execution(5);
 }
 TEST_F(CpuTest, inc_zero_sets_n_flag) {
@@ -1736,8 +1751,8 @@ TEST_F(CpuTest, inc_zero_sets_n_flag) {
     expected.p |= N_FLAG;
     stage_instruction(INC_ZERO);
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(127));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(127));
     step_execution(5);
 }
 TEST_F(CpuTest, inc_zero_clears_n_flag) {
@@ -1745,8 +1760,8 @@ TEST_F(CpuTest, inc_zero_clears_n_flag) {
     registers.p |= N_FLAG;
     stage_instruction(INC_ZERO);
 
-    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(0x44));
-    ON_CALL(mmu, read_byte(0x44)).WillByDefault(Return(125));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillRepeatedly(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x44)).WillRepeatedly(Return(125));
     step_execution(5);
 }
 
@@ -1875,7 +1890,7 @@ TEST_F(CpuTest, sta_zero) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillOnce(Return(0x44));
     EXPECT_CALL(mmu, write_byte(0x44, 0x07));
 
     step_execution(3);
@@ -1892,7 +1907,7 @@ TEST_F(CpuTest, sta_zero_x_indexed) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
     EXPECT_CALL(mmu, write_byte(u16_to_u8(0x44 + 0xED), 0x07));
 
     step_execution(4);
@@ -1924,7 +1939,7 @@ TEST_F(CpuTest, stx_zero) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
     EXPECT_CALL(mmu, write_byte(0x44, 0x07));
 
     step_execution(3);
@@ -1941,7 +1956,7 @@ TEST_F(CpuTest, stx_zero_y_indexed) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
     EXPECT_CALL(mmu, write_byte(u16_to_u8(0x44 + 0xED), 0x07));
 
     step_execution(4);
@@ -1959,7 +1974,12 @@ TEST_F(CpuTest, sta_abs_x_indexed) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x1234));
-    EXPECT_CALL(mmu, write_byte(0x1234 + 0xED, 0x07));
+    {
+        InSequence s;
+        EXPECT_CALL(mmu, read_byte(0x1234 + 0xED - 0x0100))
+                .WillOnce(Return(0xDEAD));
+        EXPECT_CALL(mmu, write_byte(0x1234 + 0xED, 0x07));
+    }
 
     step_execution(5);
 
@@ -1976,7 +1996,12 @@ TEST_F(CpuTest, sta_abs_y_indexed) {
     expected.pc += 2;
 
     ON_CALL(mmu, read_word(0x4322)).WillByDefault(Return(0x1234));
-    EXPECT_CALL(mmu, write_byte(0x1234 + 0xED, 0x07));
+    {
+        InSequence s;
+        EXPECT_CALL(mmu, read_byte(0x1234 + 0xED - 0x0100))
+                .WillOnce(Return(0xDEAD));
+        EXPECT_CALL(mmu, write_byte(0x1234 + 0xED, 0x07));
+    }
 
     step_execution(5);
 
@@ -1992,7 +2017,7 @@ TEST_F(CpuTest, sta_indexed_indirect) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0xAB));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0xAB));
     ON_CALL(mmu, read_word(u16_to_u8(0xAB + 0xED)))
             .WillByDefault(Return(0x1234));
     EXPECT_CALL(mmu, write_byte(0x1234, 0x07));
@@ -2011,9 +2036,9 @@ TEST_F(CpuTest, sta_indexed_indirect_handles_wraparound) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0xFF));
-    ON_CALL(mmu, read_byte(0xFF)).WillByDefault(Return(0x34));
-    ON_CALL(mmu, read_byte(0x00)).WillByDefault(Return(0x12));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0xFF));
+    EXPECT_CALL(mmu, read_byte(0xFF)).WillRepeatedly(Return(0x34));
+    EXPECT_CALL(mmu, read_byte(0x00)).WillRepeatedly(Return(0x12));
     EXPECT_CALL(mmu, write_byte(0x1234, 0x07));
 
     step_execution(6);
@@ -2030,7 +2055,7 @@ TEST_F(CpuTest, sta_indirect_indexed) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x42));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x42));
     ON_CALL(mmu, read_word(0x42)).WillByDefault(Return(0x1234));
     EXPECT_CALL(mmu, write_byte(0x1234 + 0xED, 0x07));
 
@@ -2074,7 +2099,7 @@ TEST_F(CpuTest, sty_zero) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
     EXPECT_CALL(mmu, write_byte(0x44, 0x07));
 
     step_execution(3);
@@ -2091,7 +2116,7 @@ TEST_F(CpuTest, sty_zero_x_indexed) {
 
     expected.pc += 1;
 
-    ON_CALL(mmu, read_byte(0x4322)).WillByDefault(Return(0x44));
+    EXPECT_CALL(mmu, read_byte(0x4322)).WillRepeatedly(Return(0x44));
     EXPECT_CALL(mmu, write_byte(u16_to_u8(0x44 + 0xED), 0x07));
 
     step_execution(4);


### PR DESCRIPTION
Mixing ON_CALL and EXPECT_CALL can be a bit tricky in gmock. We should also know exactly when reads are performed, so better to use EXPECT_CALL and be explicit everywhere.
Should help #107.