### PR TITLE
Add INC for indexed zeropage addressing mode

### DIFF
--- a/core/include/core/opcode.h
+++ b/core/include/core/opcode.h
@@ -149,7 +149,7 @@ enum Instruction : uint8_t {
     BeqRelative = 0xF0,
     // SbcIndirectY = 0xF1,
     // SbcZeropageX = 0xF5,
-    // IncZeropageX = 0xF6,
+    IncZeropageX = 0xF6,
     SedImplied = 0xF8,
     // SbcAbsoluteY = 0xF9,
     // SbcAbsoluteX = 0xFD,
@@ -224,6 +224,8 @@ enum class AddressMode {
     IndirectIndexed
 };
 
+enum class MemoryAccess { Read, Write, ReadWrite };
+
 struct Opcode {
     Family family;
     Instruction instruction;
@@ -231,6 +233,8 @@ struct Opcode {
 };
 
 Opcode decode(const uint8_t op);
+
+MemoryAccess get_memory_access(const Family family);
 
 std::string to_string(const Family family);
 

--- a/core/src/mos6502.h
+++ b/core/src/mos6502.h
@@ -81,6 +81,7 @@ private:
     Pipeline parse_next_instruction();
 
     Pipeline create_branch_instruction(const std::function<bool()> &condition);
+    Pipeline create_inc_instruction(Opcode opcode);
     Pipeline create_add_instruction(Opcode opcode);
     Pipeline create_and_instruction(Opcode opcode);
     Pipeline create_store_instruction(Opcode opcode);
@@ -89,10 +90,11 @@ private:
     Pipeline create_eor_instruction(Opcode opcode);
 
     Pipeline create_addressing_steps(AddressMode address_mode,
-            bool is_write = false);
+            MemoryAccess access);
 
-    Pipeline create_zeropage_addressing_steps();
-    Pipeline create_zeropage_indexed_addressing_steps(const uint8_t *index_reg);
+    Pipeline create_zeropage_addressing_steps(MemoryAccess access);
+    Pipeline create_zeropage_indexed_addressing_steps(const uint8_t *index_reg,
+            MemoryAccess access);
     Pipeline create_absolute_addressing_steps();
     Pipeline create_absolute_indexed_addressing_steps(const uint8_t *index_reg,
             bool is_write);

--- a/core/src/opcode.cpp
+++ b/core/src/opcode.cpp
@@ -1,5 +1,6 @@
 #include "core/opcode.h"
 
+#include <stdexcept>
 #include <string>
 
 namespace n_e_s::core {
@@ -184,6 +185,8 @@ Opcode decode(const uint8_t op) {
         return {Family::CPX, CpxAbsolute, AddressMode::Absolute};
     case BeqRelative:
         return {Family::BEQ, BeqRelative, AddressMode::Relative};
+    case IncZeropageX:
+        return {Family::INC, IncZeropageX, AddressMode::ZeropageX};
     case SedImplied:
         return {Family::SED, SedImplied, AddressMode::Implied};
     case EorImmediate:
@@ -199,6 +202,68 @@ Opcode decode(const uint8_t op) {
         // have no real meaning, so we just use 0, 0 for them.
         return {Family::Invalid, BrkImplied, AddressMode::Implied};
     }
+}
+
+MemoryAccess get_memory_access(const Family family) {
+    switch (family) {
+    // Return Read for instructions where memory access type has no meaning.
+    // Set correct access type when we implement missing addressing modes.
+    case Family::Invalid:
+    case Family::BRK:
+    case Family::PHP:
+    case Family::BPL:
+    case Family::CLC:
+    case Family::BIT:
+    case Family::PLP:
+    case Family::AND:
+    case Family::JSR:
+    case Family::BMI:
+    case Family::SEC:
+    case Family::LSR:
+    case Family::PHA:
+    case Family::JMP:
+    case Family::BVC:
+    case Family::CLI:
+    case Family::ADC:
+    case Family::PLA:
+    case Family::RTS:
+    case Family::BVS:
+    case Family::SEI:
+    case Family::TXS:
+    case Family::BCC:
+    case Family::LDX:
+    case Family::LDY:
+    case Family::LDA:
+    case Family::BCS:
+    case Family::CLV:
+    case Family::BNE:
+    case Family::CLD:
+    case Family::CPX:
+    case Family::NOP:
+    case Family::INX:
+    case Family::INY:
+    case Family::CPY:
+    case Family::CMP:
+    case Family::BEQ:
+    case Family::SED:
+    case Family::TYA:
+    case Family::TAY:
+    case Family::TAX:
+    case Family::TSX:
+    case Family::TXA:
+    case Family::DEY:
+    case Family::DEX:
+    case Family::EOR:
+        return MemoryAccess::Read;
+    case Family::STY:
+    case Family::STA:
+    case Family::STX:
+        return MemoryAccess::Write;
+    case Family::INC:
+        return MemoryAccess::ReadWrite;
+    }
+    // Should not happen
+    throw std::logic_error("Unknown family");
 }
 
 std::string to_string(const Family family) {


### PR DESCRIPTION
Needed to handle read-write instructions. Should the MemoryAccess enum be part of the opcode instead? Or perhaps have a helper function that returns the access type from an instruction family?