### PR TITLE
Use correct timing in absolute addressing pipeline

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -629,10 +629,14 @@ Pipeline Mos6502::create_zeropage_indexed_addressing_steps(
 
 Pipeline Mos6502::create_absolute_addressing_steps() {
     Pipeline result;
-    result.push([=]() { ++registers_->pc; });
     result.push([=]() {
+        tmp_ = mmu_->read_byte(registers_->pc);
         ++registers_->pc;
-        effective_address_ = mmu_->read_word(registers_->pc - 2);
+    });
+    result.push([=]() {
+        const uint16_t upper = mmu_->read_byte(registers_->pc) << 8;
+        ++registers_->pc;
+        effective_address_ = tmp_ | upper;
     });
     return result;
 }

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -510,8 +510,13 @@ public:
         stage_instruction(instruction);
         expected.pc += 2;
 
-        EXPECT_CALL(mmu, read_word(start_pc + 1))
-                .WillOnce(Return(effective_address));
+        const uint8_t lower_address = effective_address & 0x00FF;
+        const uint8_t upper_address = (effective_address & 0xFF00) >> 8;
+
+        EXPECT_CALL(mmu, read_byte(start_pc + 1))
+                .WillOnce(Return(lower_address));
+        EXPECT_CALL(mmu, read_byte(start_pc + 2))
+                .WillOnce(Return(upper_address));
         EXPECT_CALL(mmu, read_byte(effective_address))
                 .WillOnce(Return(memory_content));
 
@@ -524,8 +529,13 @@ public:
         stage_instruction(instruction);
         expected.pc += 2;
 
-        EXPECT_CALL(mmu, read_word(start_pc + 1))
-                .WillOnce(Return(effective_address));
+        const uint8_t lower_address = effective_address & 0x00FF;
+        const uint8_t upper_address = (effective_address & 0xFF00) >> 8;
+
+        EXPECT_CALL(mmu, read_byte(start_pc + 1))
+                .WillOnce(Return(lower_address));
+        EXPECT_CALL(mmu, read_byte(start_pc + 2))
+                .WillOnce(Return(upper_address));
         EXPECT_CALL(mmu, write_byte(effective_address, memory_content));
 
         step_execution(4);
@@ -833,7 +843,8 @@ TEST_F(CpuTest, jsr) {
     const uint8_t expected_pc_stack_addr = expected.sp - 1;
     expected.sp -= 2; // 1 word
 
-    EXPECT_CALL(mmu, read_word(registers.pc + 1)).WillOnce(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0xAD));
+    EXPECT_CALL(mmu, read_byte(registers.pc + 2)).WillOnce(Return(0xDE));
 
     EXPECT_CALL(mmu,
             write_word(


### PR DESCRIPTION
Part of #107.

Requires #134, will rebase once it is merged.