### PR TITLE
Drop the plain VS2017 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,6 @@ configuration:
 
 environment:
   matrix:
-  - TOOLCHAIN: Msvc 2017 x86
-    GENERATOR: Visual Studio 15 2017
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-  - TOOLCHAIN: Msvc 2017 x64
-    GENERATOR: Visual Studio 15 2017 Win64
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
   - TOOLCHAIN: Msvc 2019 x86
     GENERATOR: Visual Studio 16 2019
     CMAKE_ARGS: -A Win32


### PR DESCRIPTION
The Appveyor builds take the longest by far, and we're still testing VS2017 to some degree with the ninja builds, and really, who wants to support old things when there are new and shiny things available?