### PR TITLE
Use travis_wait for clang-tidy job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
             - libstdc++-7-dev
       script:
         - CXX=clang++-7 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-        - run-clang-tidy-7.py -q -p . "application|core|nes" -header-filter=".*"
+        - travis_wait run-clang-tidy-7.py -q -p . "application|core|nes" -header-filter=".*"
 
     - name: "clang-format"
       addons:


### PR DESCRIPTION
* We sometimes get the following error message on travis:
"No output has been received in the last 10m0s, this potentially
indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on:
https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received"
* Try using travis_wait to increase the timeout