### PR TITLE
Initialize cpu registers according to nes power up state

### DIFF
--- a/nes/src/nes.cpp
+++ b/nes/src/nes.cpp
@@ -44,7 +44,14 @@ public:
               ppu(PpuFactory::create(&ppu_registers, ppu_mmu.get())),
               mmu(MmuFactory::create(
                       MemBankFactory::create_nes_mem_banks(ppu.get()))),
-              cpu(CpuFactory::create_mos6502(&cpu_registers, mmu.get())) {}
+              cpu(CpuFactory::create_mos6502(&cpu_registers, mmu.get())) {
+        // P should be set to 0x34 according to the information here:
+        // https://wiki.nesdev.com/w/index.php/CPU_power_up_state
+        // However, nestest sets p to 0x24 instead. We do that for now as well.
+        cpu_registers.p = I_FLAG | FLAG_5;
+        cpu_registers.a = cpu_registers.x = cpu_registers.y = 0x00;
+        cpu_registers.sp = 0xFD;
+    }
 
     void execute() {
         if (cycle++ % 3 == 0) {


### PR DESCRIPTION
See: https://wiki.nesdev.com/w/index.php/CPU_power_up_state

Also see the note at the bottom:
"The golden log of nestest differs from this in the irrelevant bits 5 and 4 of P"

I guess we want to use the same state as nestest to simplify testing?