### PR TITLE
Make sure bitwise operations always use unsigned values

### DIFF
--- a/core/include/core/imos6502.h
+++ b/core/include/core/imos6502.h
@@ -9,14 +9,14 @@
 namespace n_e_s::core {
 
 enum CpuFlag {
-    C_FLAG = 1 << 0, // carry
-    Z_FLAG = 1 << 1, // zero
-    I_FLAG = 1 << 2, // interrupt disable
-    D_FLAG = 1 << 3, // decimal mode
-    B_FLAG = 1 << 4, // break
-    FLAG_5 = 1 << 5, // unused, always 1
-    V_FLAG = 1 << 6, // overflow
-    N_FLAG = 1 << 7, // negative
+    C_FLAG = 1u << 0u, // carry
+    Z_FLAG = 1u << 1u, // zero
+    I_FLAG = 1u << 2u, // interrupt disable
+    D_FLAG = 1u << 3u, // decimal mode
+    B_FLAG = 1u << 4u, // break
+    FLAG_5 = 1u << 5u, // unused, always 1
+    V_FLAG = 1u << 6u, // overflow
+    N_FLAG = 1u << 7u, // negative
 };
 
 struct CpuRegisters {

--- a/core/src/mmu.cpp
+++ b/core/src/mmu.cpp
@@ -42,7 +42,7 @@ uint8_t Mmu::read_byte(uint16_t addr) const {
 uint16_t Mmu::read_word(uint16_t addr) const {
     if (const IMemBank *mem_bank = get_mem_bank(addr)) {
         return static_cast<uint16_t>(
-                mem_bank->read_byte(addr) | mem_bank->read_byte(addr + 1) << 8);
+                mem_bank->read_byte(addr) | static_cast<uint16_t>(mem_bank->read_byte(addr + 1) << 8u));
     }
 
     throw InvalidAddress(addr);
@@ -58,8 +58,8 @@ void Mmu::write_byte(uint16_t addr, uint8_t byte) {
 
 void Mmu::write_word(uint16_t addr, uint16_t word) {
     if (IMemBank *mem_bank = get_mem_bank(addr)) {
-        mem_bank->write_byte(addr, word & 0xFF);
-        mem_bank->write_byte(addr + 1, word >> 8);
+        mem_bank->write_byte(addr, word & 0xFFu);
+        mem_bank->write_byte(addr + 1, word >> 8u);
     } else {
         throw InvalidAddress(addr);
     }

--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -12,11 +12,11 @@ const uint16_t kResetAddress = 0xFFFC; // This is where the reset routine is.
 const uint16_t kBrkAddress = 0xFFFE; // This is where the break routine is.
 
 constexpr bool is_negative(uint8_t byte) {
-    return byte & (1 << 7);
+    return byte & (1u << 7u);
 }
 
 constexpr uint8_t low_bits(uint8_t byte) {
-    return byte & ~(1 << 7);
+    return byte & ~(1u << 7u);
 }
 
 constexpr int8_t to_signed(uint8_t byte) {
@@ -28,13 +28,13 @@ constexpr int8_t to_signed(uint8_t byte) {
 }
 
 constexpr uint16_t high_byte(uint16_t word) {
-    return word & 0xFF00;
+    return word & 0xFF00u;
 }
 
 // Returns true if accessing an index address will require the cpu to reach
 // across a page boundary.
 constexpr bool cross_page(uint16_t address, uint8_t index) {
-    return ((address + index) & 0xFF00) != (address & 0xFF00);
+    return (static_cast<uint16_t>(address + index) & 0xFF00u) != (address & 0xFF00u);
 }
 
 } // namespace
@@ -100,12 +100,12 @@ Pipeline Mos6502::parse_next_instruction() {
             // Dummy read
             mmu_->read_byte(registers_->pc++);
         });
-        result.push([=]() { stack_.push_byte(registers_->pc >> 8); });
-        result.push([=]() { stack_.push_byte(registers_->pc & 0xFF); });
+        result.push([=]() { stack_.push_byte(registers_->pc >> 8u); });
+        result.push([=]() { stack_.push_byte(registers_->pc & 0xFFu); });
         result.push([=]() { stack_.push_byte(registers_->p | B_FLAG); });
         result.push([=]() { tmp_ = mmu_->read_byte(kBrkAddress); });
         result.push([=]() {
-            const uint16_t pch = mmu_->read_byte(kBrkAddress + 1) << 8;
+            const uint16_t pch = mmu_->read_byte(kBrkAddress + 1) << 8u;
             registers_->pc = pch | tmp_;
         });
         break;
@@ -128,7 +128,7 @@ Pipeline Mos6502::parse_next_instruction() {
             const uint8_t value = mmu_->read_byte(effective_address_);
             set_zero(value & registers_->a);
             set_negative(value);
-            if (value & (1u << 6)) {
+            if (value & (1u << 6u)) {
                 set_flag(V_FLAG);
             } else {
                 clear_flag(V_FLAG);
@@ -170,9 +170,9 @@ Pipeline Mos6502::parse_next_instruction() {
         break;
     case Instruction::LsrAccumulator:
         result.push([=]() {
-            set_carry(registers_->a & 1);
-            registers_->a &= ~1;
-            registers_->a >>= 1;
+            set_carry(registers_->a & 1u);
+            registers_->a &= ~1u;
+            registers_->a >>= 1u;
             set_zero(registers_->a);
             clear_flag(N_FLAG);
         });
@@ -416,7 +416,7 @@ Pipeline Mos6502::parse_next_instruction() {
     case RolAccumulator:
         result.push([=]() {
             const uint8_t carry = registers_->p & C_FLAG ? 0x01 : 0x00;
-            const uint16_t temp_result = (registers_->a << 1) | carry;
+            const uint16_t temp_result = static_cast<uint16_t>(registers_->a << 1u) | carry;
             registers_->a = static_cast<uint8_t>(temp_result);
             set_carry(temp_result > 0xFF);
             set_zero(registers_->a);
@@ -426,8 +426,8 @@ Pipeline Mos6502::parse_next_instruction() {
     case Instruction::RorAccumulator:
         result.push([=]() {
             const uint8_t carry_in = registers_->p & C_FLAG ? 0x80 : 0x00;
-            const bool carry_out = (registers_->a & 0x01) == 0x01;
-            const uint16_t temp_result = (registers_->a >> 1) | carry_in;
+            const bool carry_out = (registers_->a & 0x01u) == 0x01;
+            const uint16_t temp_result = static_cast<uint16_t>(registers_->a >> 1u) | carry_in;
             registers_->a = static_cast<uint8_t>(temp_result);
             set_carry(carry_out);
             set_zero(registers_->a);
@@ -460,7 +460,7 @@ void Mos6502::set_nmi(bool nmi) {
 }
 
 void Mos6502::clear_flag(uint8_t flag) {
-    registers_->p &= ~flag;
+    registers_->p &= static_cast<uint8_t>(~flag);
 }
 
 void Mos6502::set_flag(uint8_t flag) {
@@ -495,8 +495,9 @@ void Mos6502::set_overflow(uint8_t reg_value,
         uint8_t operand,
         uint16_t resulting_value) {
     // See: http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
-    const bool overflow = ((reg_value ^ resulting_value) &
-                                  (operand ^ resulting_value) & 0x80) != 0;
+    auto a = static_cast<uint8_t>(reg_value ^ resulting_value);
+    auto b = static_cast<uint8_t>(operand ^ resulting_value);
+    const bool overflow = (static_cast<uint8_t>(a & b) & 0x80u) != 0;
     if (overflow) {
         set_flag(V_FLAG);
     } else {
@@ -514,12 +515,12 @@ Pipeline Mos6502::create_nmi() {
         // Dummy read
         mmu_->read_byte(registers_->pc++);
     });
-    result.push([=]() { stack_.push_byte(registers_->pc >> 8); });
-    result.push([=]() { stack_.push_byte(registers_->pc & 0xFF); });
+    result.push([=]() { stack_.push_byte(registers_->pc >> 8u); });
+    result.push([=]() { stack_.push_byte(registers_->pc & 0xFFu); });
     result.push([=]() { stack_.push_byte(registers_->p); });
     result.push([=]() { tmp_ = mmu_->read_byte(0xFFFA); });
     result.push([=]() {
-        const uint16_t pch = mmu_->read_byte(0xFFFB) << 8;
+        const uint16_t pch = mmu_->read_byte(0xFFFB) << 8u;
         registers_->pc = pch | tmp_;
     });
 
@@ -818,7 +819,7 @@ Pipeline Mos6502::create_absolute_addressing_steps() {
         ++registers_->pc;
     });
     result.push([=]() {
-        const uint16_t upper = mmu_->read_byte(registers_->pc) << 8;
+        const uint16_t upper = mmu_->read_byte(registers_->pc) << 8u;
         ++registers_->pc;
         effective_address_ = tmp_ | upper;
     });
@@ -879,7 +880,7 @@ Pipeline Mos6502::create_indexed_indirect_addressing_steps() {
             // Special case where the effective address should come from
             // 0x00 and 0xFF, not 0x0100 and 0x00FF.
             const uint8_t lower = mmu_->read_byte(address);
-            const uint16_t upper = mmu_->read_byte(0x00) << 8;
+            const uint16_t upper = mmu_->read_byte(0x00) << 8u;
             effective_address_ = upper | lower;
         } else {
             effective_address_ = mmu_->read_word(address);

--- a/core/src/ppu.cpp
+++ b/core/src/ppu.cpp
@@ -64,9 +64,9 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
         // enabled (bit 7). If this is the case and we currently are in
         // vertical blanking a NMI shall be generated.
         registers_->ctrl = byte;
-        uint16_t name_table_bits = (byte & 3);
-        registers_->temp_vram_addr &= 0b1111'0011'1111'1111;
-        registers_->temp_vram_addr |= (name_table_bits << 10);
+        uint16_t name_table_bits = (byte & 3u);
+        registers_->temp_vram_addr &= static_cast<uint16_t>(0b1111'0011'1111'1111);
+        registers_->temp_vram_addr |= static_cast<uint16_t>(name_table_bits << 10u);
     } else if (addr == kPpuMask) {
         registers_->mask = byte;
     } else if (addr == kOamAddr) {
@@ -77,17 +77,17 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
         }
     } else if (addr == kPpuScroll) {
         if (registers_->write_toggle) { // Second write, Y scroll
-            uint16_t y_scroll = (byte >> 3);
-            uint16_t fine_y_scroll = (byte & 7);
-            registers_->temp_vram_addr &= 0b1000'1100'0001'1111;
-            registers_->temp_vram_addr |= (y_scroll << 5);
-            registers_->temp_vram_addr |= (fine_y_scroll << 12);
+            uint16_t y_scroll = (byte >> 3u);
+            uint16_t fine_y_scroll = (byte & 7u);
+            registers_->temp_vram_addr &= static_cast<uint16_t>(0b1000'1100'0001'1111);
+            registers_->temp_vram_addr |= static_cast<uint16_t>(y_scroll << 5u);
+            registers_->temp_vram_addr |= static_cast<uint16_t>(fine_y_scroll << 12u);
             registers_->write_toggle = false;
         } else { // First write, X Scroll
-            uint16_t x_scroll = (byte >> 3);
-            registers_->temp_vram_addr &= 0b1111'1111'1110'0000;
+            uint16_t x_scroll = (byte >> 3u);
+            registers_->temp_vram_addr &= static_cast<uint16_t>(0b1111'1111'1110'0000);
             registers_->temp_vram_addr |= x_scroll;
-            registers_->fine_x_scroll = (byte & 7);
+            registers_->fine_x_scroll = (byte & 7u);
             registers_->write_toggle = true;
         }
     } else if (addr == kPpuAddr) {
@@ -97,7 +97,7 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
             registers_->write_toggle = false;
         } else { // First write, upper address byte
             uint16_t upper_addr_byte = byte;
-            registers_->temp_vram_addr = (upper_addr_byte << 8);
+            registers_->temp_vram_addr = (upper_addr_byte << 8u);
             registers_->write_toggle = true;
         }
     } else if (addr == kPpuData) {
@@ -153,7 +153,7 @@ bool Ppu::is_vblank_scanline() const {
 }
 
 bool Ppu::is_rendering_enabled() const {
-    return (registers_->mask & (1 << 3)) || (registers_->mask & (1 << 4));
+    return (registers_->mask & (1u << 3u)) || (registers_->mask & (1u << 4u));
 }
 
 bool Ppu::is_rendering_active() const {
@@ -164,7 +164,7 @@ bool Ppu::is_rendering_active() const {
 uint8_t Ppu::get_vram_address_increment() const {
     uint8_t addr_increment = 1;
 
-    if (registers_->ctrl & (1 << 2)) {
+    if (registers_->ctrl & (1u << 2u)) {
         addr_increment = 32;
     }
 
@@ -192,11 +192,11 @@ void Ppu::execute_vblank_scanline() {
 }
 
 void Ppu::set_vblank_flag() {
-    registers_->status |= (1 << 7);
+    registers_->status |= (1u << 7u);
 }
 
 void Ppu::clear_vblank_flag() {
-    registers_->status &= ~(1 << 7);
+    registers_->status &= ~(1u << 7u);
 }
 
 } // namespace n_e_s::core

--- a/core/src/rom_factory.cpp
+++ b/core/src/rom_factory.cpp
@@ -58,8 +58,8 @@ std::unique_ptr<IRom> RomFactory::from_bytes(std::istream &bytestream) {
         h.prg_ram_size = 1; // For compatibility reasons, 0 ram means 1 ram.
     }
 
-    uint8_t mapper = (h.flags_6 & 0xF0) >> 4;
-    mapper |= h.flags_7 & 0xF0;
+    uint8_t mapper = (h.flags_6 & 0xF0u) >> 4u;
+    mapper |= h.flags_7 & 0xF0u;
 
     const uint32_t prg_rom_byte_count = h.prg_rom_size * 16 * 1024;
     const uint32_t chr_rom_byte_count = h.chr_rom_size * 8 * 1024;

--- a/core/test/src/fake_mmu.h
+++ b/core/test/src/fake_mmu.h
@@ -22,7 +22,7 @@ public:
 
     uint16_t read_word(uint16_t addr) const override {
         const uint8_t low = read_byte(addr);
-        const uint16_t upper = read_byte(addr + 1) << 8;
+        const uint16_t upper = read_byte(addr + 1) << 8u;
         return low | upper;
     }
 
@@ -31,8 +31,8 @@ public:
     }
 
     void write_word(uint16_t addr, uint16_t word) override {
-        const uint8_t low = word & 0xFF;
-        const uint8_t upper = word >> 8;
+        const uint8_t low = word & 0xFFu;
+        const uint8_t upper = word >> 8u;
         write_byte(addr, low);
         write_byte(addr + 1, upper);
     }

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -299,7 +299,7 @@ public:
 
     void compare_abs_sets_n_c(uint8_t *reg, uint8_t *expected_reg) {
         *expected_reg = *reg = 0;
-        expected.p |= N_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
         registers.p |= Z_FLAG;
         expected.pc += 2;
 
@@ -315,7 +315,7 @@ public:
         registers.a = expected.a = 0x07;
         *index_reg = *index_reg_expected = 0x10;
         registers.p |= N_FLAG;
-        expected.p |= Z_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(Z_FLAG | C_FLAG);
 
         expected.pc += 2;
 
@@ -331,7 +331,7 @@ public:
         registers.a = expected.a = 0x07;
         *index_reg = *index_reg_expected = 0xAB;
         registers.p |= N_FLAG;
-        expected.p |= Z_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(Z_FLAG | C_FLAG);
 
         expected.pc += 2;
 
@@ -454,7 +454,7 @@ public:
             uint8_t *expected_reg) {
         *expected_reg = *reg = 0b10001111;
         expected.p |= N_FLAG;
-        registers.p |= Z_FLAG | C_FLAG;
+        registers.p |= static_cast<uint8_t>(Z_FLAG | C_FLAG);
         memory_content = 0b00001000;
 
         run_instruction(instruction);
@@ -465,7 +465,7 @@ public:
             uint8_t *expected_reg) {
         *expected_reg = *reg = 0x02;
         expected.p |= C_FLAG;
-        registers.p |= Z_FLAG | N_FLAG;
+        registers.p |= static_cast<uint8_t>(Z_FLAG | N_FLAG);
         memory_content = 0xFA;
 
         run_instruction(instruction);
@@ -475,7 +475,7 @@ public:
             uint8_t *reg,
             uint8_t *expected_reg) {
         *expected_reg = *reg = 42;
-        expected.p |= Z_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(Z_FLAG | C_FLAG);
         registers.p |= N_FLAG;
         memory_content = 42;
 
@@ -486,7 +486,7 @@ public:
             uint8_t *reg,
             uint8_t *expected_reg) {
         *expected_reg = *reg = 0;
-        expected.p |= N_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
         registers.p |= Z_FLAG;
         memory_content = 127;
 
@@ -553,7 +553,7 @@ public:
             uint8_t *reg,
             uint8_t *expected_reg) {
         *expected_reg = *reg = 0;
-        expected.p |= N_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
         registers.p |= Z_FLAG;
         memory_content = 127;
 
@@ -572,8 +572,8 @@ public:
         stage_instruction(instruction);
         expected.pc += 2;
 
-        const uint8_t lower_address = effective_address & 0x00FF;
-        const uint8_t upper_address = (effective_address & 0xFF00) >> 8;
+        const uint8_t lower_address = effective_address & 0x00FFu;
+        const uint8_t upper_address = (effective_address & 0xFF00u) >> 8u;
 
         EXPECT_CALL(mmu, read_byte(start_pc + 1))
                 .WillOnce(Return(lower_address));
@@ -591,8 +591,8 @@ public:
         stage_instruction(instruction);
         expected.pc += 2;
 
-        const uint8_t lower_address = effective_address & 0x00FF;
-        const uint8_t upper_address = (effective_address & 0xFF00) >> 8;
+        const uint8_t lower_address = effective_address & 0x00FFu;
+        const uint8_t upper_address = (effective_address & 0xFF00u) >> 8u;
 
         EXPECT_CALL(mmu, read_byte(start_pc + 1))
                 .WillOnce(Return(lower_address));
@@ -608,7 +608,7 @@ public:
             uint8_t *reg,
             uint8_t *expected_reg) {
         *expected_reg = *reg = 0;
-        expected.p |= N_FLAG | C_FLAG;
+        expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
         registers.p |= Z_FLAG;
         memory_content = 127;
         run_read_instruction(instruction);
@@ -933,7 +933,7 @@ TEST_F(CpuTest, clc) {
     expected.p = registers.p = 0xFF;
 
     stage_instruction(CLC);
-    expected.p &= ~C_FLAG;
+    expected.p &= static_cast<uint8_t>(~C_FLAG);
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1033,7 +1033,7 @@ TEST_F(CpuTest, lsr_a_sets_c_and_z_flags) {
 TEST_F(CpuTest, lsr_a_clears_c_z_n_flags) {
     stage_instruction(LSR_ACC);
     registers.a = 0b00000010;
-    registers.p = Z_FLAG | C_FLAG | N_FLAG;
+    registers.p = static_cast<uint8_t>(Z_FLAG | C_FLAG) | N_FLAG;
     expected.a = 0b00000001;
     expected.p = 0;
 
@@ -1672,7 +1672,7 @@ TEST_F(CpuTest, cld) {
     expected.p = registers.p = 0xFF;
 
     stage_instruction(CLD);
-    expected.p &= ~D_FLAG;
+    expected.p &= static_cast<uint8_t>(~D_FLAG);
 
     step_execution(2);
     EXPECT_EQ(expected, registers);
@@ -1757,7 +1757,7 @@ TEST_F(CpuTest, cmp_indirect_indexed_with_pagecrossing_sets_nc) {
     registers.pc = expected.pc = 0x4321;
     registers.y = expected.y = 0xED;
     registers.a = expected.a = 0x07;
-    expected.p |= N_FLAG | C_FLAG;
+    expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
     registers.p |= Z_FLAG;
 
     stage_instruction(CMP_INDINX);
@@ -1778,7 +1778,7 @@ TEST_F(CpuTest, cmp_indirect_indexed_without_pagecrossing_sets_nc) {
     registers.pc = expected.pc = 0x4321;
     registers.y = expected.y = 0x0D;
     registers.a = expected.a = 0x07;
-    expected.p |= N_FLAG | C_FLAG;
+    expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
     registers.p |= Z_FLAG;
 
     stage_instruction(CMP_INDINX);
@@ -1798,7 +1798,7 @@ TEST_F(CpuTest, cmp_indexed_indirect_sets_nc) {
     registers.pc = expected.pc = 0x4321;
     registers.x = expected.x = 0xED;
     registers.a = expected.a = 0x07;
-    expected.p |= N_FLAG | C_FLAG;
+    expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
     registers.p |= Z_FLAG;
 
     stage_instruction(CMP_INXIND);
@@ -1819,7 +1819,7 @@ TEST_F(CpuTest, cmp_indexed_indirect_handles_wraparound_sets_nc) {
     registers.pc = expected.pc = 0x4321;
     registers.x = expected.x = 0x00;
     registers.a = expected.a = 0x07;
-    expected.p |= N_FLAG | C_FLAG;
+    expected.p |= static_cast<uint8_t>(N_FLAG | C_FLAG);
     registers.p |= Z_FLAG;
 
     stage_instruction(CMP_INXIND);
@@ -1852,7 +1852,7 @@ TEST_F(CpuTest, cmp_zero_x_sets_zc) {
     registers.a = expected.a = 0x07;
     registers.x = expected.x = 0xED;
     registers.p |= N_FLAG;
-    expected.p |= Z_FLAG | C_FLAG;
+    expected.p |= static_cast<uint8_t>(Z_FLAG | C_FLAG);
 
     stage_instruction(CMP_ZEROX);
 

--- a/core/test/src/test_rom.cpp
+++ b/core/test/src/test_rom.cpp
@@ -15,8 +15,8 @@ std::string ines_header_bytes(const uint8_t mapper,
         const uint8_t chr_rom_size,
         const uint8_t prg_ram_size) {
     INesHeader header{};
-    header.flags_6 = mapper & 0x0F << 4;
-    header.flags_7 = mapper & 0xF0;
+    header.flags_6 = mapper & 0x0Fu << 4u;
+    header.flags_7 = mapper & 0xF0u;
     header.prg_rom_size = prg_rom_size;
     header.chr_rom_size = chr_rom_size;
     header.prg_ram_size = prg_ram_size;


### PR DESCRIPTION
Currently most bitwise operations are done with temporary signed ints against the common uint8_t, unit16_t, etc. The behavior of this is compiler implementation specific and could result in UB. Furthermore, it causes a lot of clang tidy warnings.

This will remove all warnings of the type: "Use of a signed integer operand with a binary bitwise operator"