### PR TITLE
Fix CLion code inspection warnings

### DIFF
--- a/core/src/mmu.cpp
+++ b/core/src/mmu.cpp
@@ -41,9 +41,10 @@ uint8_t Mmu::read_byte(uint16_t addr) const {
 
 uint16_t Mmu::read_word(uint16_t addr) const {
     if (const IMemBank *mem_bank = get_mem_bank(addr)) {
-        return static_cast<uint16_t>(
-                mem_bank->read_byte(addr) |
-                static_cast<uint16_t>(mem_bank->read_byte(addr + 1) << 8u));
+        auto low = mem_bank->read_byte(addr);
+        auto high = static_cast<uint16_t>(
+                mem_bank->read_byte(addr + static_cast<uint16_t>(1)) << 8u);
+        return high | low;
     }
 
     throw InvalidAddress(addr);
@@ -59,8 +60,9 @@ void Mmu::write_byte(uint16_t addr, uint8_t byte) {
 
 void Mmu::write_word(uint16_t addr, uint16_t word) {
     if (IMemBank *mem_bank = get_mem_bank(addr)) {
-        mem_bank->write_byte(addr, word & 0xFFu);
-        mem_bank->write_byte(addr + 1, word >> 8u);
+        mem_bank->write_byte(addr, static_cast<uint8_t>(word & 0xFFu));
+        mem_bank->write_byte(addr + static_cast<uint16_t>(1),
+                static_cast<uint8_t>(word >> 8u));
     } else {
         throw InvalidAddress(addr);
     }

--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -1,6 +1,6 @@
 #include "core/mmu_factory.h"
 
-#include "membank.h"
+#include "core/imembank.h"
 #include "mmu.h"
 
 namespace n_e_s::core {

--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -12,7 +12,7 @@ std::unique_ptr<IMmu> MmuFactory::create(MemBankList mem_banks) {
         mmu->add_mem_bank(std::move(mem_bank));
     }
 
-    return mmu;
+    return std::move(mmu);
 }
 
 } // namespace n_e_s::core

--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -11,23 +11,24 @@ const uint16_t kResetAddress = 0xFFFC; // This is where the reset routine is.
 const uint16_t kBrkAddress = 0xFFFE; // This is where the break routine is.
 
 constexpr bool is_negative(uint8_t byte) {
-    return byte & (1u << 7u);
+    return (byte & (1u << 7u)) != 0;
 }
 
 constexpr uint8_t low_bits(uint8_t byte) {
-    return byte & ~(1u << 7u);
+    return static_cast<uint8_t>(
+            byte & static_cast<uint8_t>(~static_cast<uint8_t>(1u << 7u)));
 }
 
 constexpr int8_t to_signed(uint8_t byte) {
     if (is_negative(byte)) {
-        return low_bits(byte) - 128;
+        return low_bits(byte) - static_cast<uint8_t>(128);
     }
 
     return low_bits(byte);
 }
 
 constexpr uint16_t high_byte(uint16_t word) {
-    return word & 0xFF00u;
+    return word & static_cast<uint16_t>(0xFF00u);
 }
 
 // Returns true if accessing an index address will require the cpu to reach
@@ -100,8 +101,12 @@ Pipeline Mos6502::parse_next_instruction() {
             // Dummy read
             mmu_->read_byte(registers_->pc++);
         });
-        result.push([=]() { stack_.push_byte(registers_->pc >> 8u); });
-        result.push([=]() { stack_.push_byte(registers_->pc & 0xFFu); });
+        result.push([=]() {
+            stack_.push_byte(static_cast<uint8_t>(registers_->pc >> 8u));
+        });
+        result.push([=]() {
+            stack_.push_byte(static_cast<uint8_t>(registers_->pc & 0xFFu));
+        });
         result.push([=]() { stack_.push_byte(registers_->p | B_FLAG); });
         result.push([=]() { tmp_ = mmu_->read_byte(kBrkAddress); });
         result.push([=]() {
@@ -170,7 +175,7 @@ Pipeline Mos6502::parse_next_instruction() {
         break;
     case Instruction::LsrAccumulator:
         result.push([=]() {
-            set_carry(registers_->a & 1u);
+            set_carry((registers_->a & 1u) != 0);
             registers_->a &= ~1u;
             registers_->a >>= 1u;
             set_zero(registers_->a);
@@ -186,7 +191,8 @@ Pipeline Mos6502::parse_next_instruction() {
     case Instruction::JmpAbsolute:
         result.push([=]() { ++registers_->pc; });
         result.push([=]() {
-            registers_->pc = mmu_->read_word(registers_->pc - 1);
+            registers_->pc =
+                    mmu_->read_word(registers_->pc - static_cast<uint16_t>(1));
         });
         break;
     case Instruction::BvcRelative:
@@ -425,7 +431,9 @@ Pipeline Mos6502::parse_next_instruction() {
         break;
     case RolAccumulator:
         result.push([=]() {
-            const uint8_t carry = registers_->p & C_FLAG ? 0x01 : 0x00;
+            const uint8_t carry = registers_->p & C_FLAG
+                                          ? static_cast<uint8_t>(0x01)
+                                          : static_cast<uint8_t>(0x00);
             const uint16_t temp_result =
                     static_cast<uint16_t>(registers_->a << 1u) | carry;
             registers_->a = static_cast<uint8_t>(temp_result);
@@ -436,7 +444,9 @@ Pipeline Mos6502::parse_next_instruction() {
         break;
     case Instruction::RorAccumulator:
         result.push([=]() {
-            const uint8_t carry_in = registers_->p & C_FLAG ? 0x80 : 0x00;
+            const uint8_t carry_in = registers_->p & C_FLAG
+                                             ? static_cast<uint8_t>(0x80)
+                                             : static_cast<uint8_t>(0x00);
             const bool carry_out = (registers_->a & 0x01u) == 0x01;
             const uint16_t temp_result =
                     static_cast<uint16_t>(registers_->a >> 1u) | carry_in;
@@ -527,8 +537,12 @@ Pipeline Mos6502::create_nmi() {
         // Dummy read
         mmu_->read_byte(registers_->pc++);
     });
-    result.push([=]() { stack_.push_byte(registers_->pc >> 8u); });
-    result.push([=]() { stack_.push_byte(registers_->pc & 0xFFu); });
+    result.push([=]() {
+        stack_.push_byte(static_cast<uint8_t>(registers_->pc >> 8u));
+    });
+    result.push([=]() {
+        stack_.push_byte(static_cast<uint8_t>(registers_->pc & 0xFFu));
+    });
     result.push([=]() { stack_.push_byte(registers_->p); });
     result.push([=]() { tmp_ = mmu_->read_byte(0xFFFA); });
     result.push([=]() {
@@ -575,7 +589,7 @@ Pipeline Mos6502::create_inc_instruction(const Opcode opcode) {
     result.append(create_addressing_steps(opcode.address_mode, memory_access));
 
     result.push([=]() {
-        const uint8_t new_value = tmp_ + 1;
+        const uint8_t new_value = tmp_ + static_cast<uint8_t>(1);
         set_zero(new_value);
         set_negative(new_value);
         mmu_->write_byte(effective_address_, new_value);
@@ -590,7 +604,7 @@ Pipeline Mos6502::create_dec_instruction(const Opcode opcode) {
     result.append(create_addressing_steps(opcode.address_mode, memory_access));
 
     result.push([=]() {
-        const uint8_t new_value = tmp_ - 1;
+        const uint8_t new_value = tmp_ - static_cast<uint8_t>(1);
         set_zero(new_value);
         set_negative(new_value);
         mmu_->write_byte(effective_address_, new_value);
@@ -601,7 +615,8 @@ Pipeline Mos6502::create_dec_instruction(const Opcode opcode) {
 
 void Mos6502::adc_impl(const uint8_t addend) {
     const uint8_t a_before = registers_->a;
-    const uint8_t carry = registers_->p & C_FLAG ? 1u : 0u;
+    const uint8_t carry = registers_->p & C_FLAG ? static_cast<uint8_t>(1u)
+                                                 : static_cast<uint8_t>(0u);
     const uint16_t temp_result = registers_->a + addend + carry;
     registers_->a = static_cast<uint8_t>(temp_result);
 
@@ -865,7 +880,8 @@ Pipeline Mos6502::create_absolute_indexed_addressing_steps(
     result.push([=]() { ++registers_->pc; });
     result.push([=]() {
         ++registers_->pc;
-        const uint16_t abs_address = mmu_->read_word(registers_->pc - 2);
+        const uint16_t abs_address =
+                mmu_->read_word(registers_->pc - static_cast<uint16_t>(2));
         const uint8_t offset = *index_reg;
 
         is_crossing_page_boundary_ = cross_page(abs_address, offset);
@@ -878,7 +894,8 @@ Pipeline Mos6502::create_absolute_indexed_addressing_steps(
                 // The high byte of the effective address is invalid
                 // at this time (smaller by $100), but a read is still
                 // performed.
-                mmu_->read_byte(effective_address_ - 0x0100);
+                mmu_->read_byte(
+                        effective_address_ - static_cast<uint16_t>(0x0100));
             } else {
                 // Extra read from effective address.
                 mmu_->read_byte(effective_address_);
@@ -890,7 +907,8 @@ Pipeline Mos6502::create_absolute_indexed_addressing_steps(
                 // The high byte of the effective address is invalid
                 // at this time (smaller by $100), but a read is still
                 // performed.
-                mmu_->read_byte(effective_address_ - 0x0100);
+                mmu_->read_byte(
+                        effective_address_ - static_cast<uint16_t>(0x0100));
                 return StepResult::Continue;
             }
             return StepResult::Skip;
@@ -939,7 +957,8 @@ Pipeline Mos6502::create_indirect_indexed_addressing_steps(bool is_write) {
                 // The high byte of the effective address is invalid
                 // at this time (smaller by $100), but a read is still
                 // performed.
-                mmu_->read_byte(effective_address_ - 0x0100);
+                mmu_->read_byte(
+                        effective_address_ - static_cast<uint16_t>(0x0100));
             } else {
                 // Extra read from effective address.
                 mmu_->read_byte(effective_address_);
@@ -951,7 +970,8 @@ Pipeline Mos6502::create_indirect_indexed_addressing_steps(bool is_write) {
                 // The high byte of the effective address is invalid
                 // at this time (smaller by $100), but a read is still
                 // performed.
-                mmu_->read_byte(effective_address_ - 0x0100);
+                mmu_->read_byte(
+                        effective_address_ - static_cast<uint16_t>(0x0100));
                 return StepResult::Continue;
             }
             return StepResult::Skip;

--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -2,7 +2,6 @@
 
 #include "core/opcode.h"
 
-#include <cassert>
 #include <sstream>
 #include <stdexcept>
 

--- a/core/src/opcode.cpp
+++ b/core/src/opcode.cpp
@@ -426,9 +426,10 @@ std::string to_string(const Family family) {
         return "ORA";
     case Family::SBC:
         return "SBC";
-    default:
-        return "UNKNOWN";
     }
+
+    // Should not happen
+    throw std::logic_error("Unknown family");
 }
 
 } // namespace n_e_s::core

--- a/core/src/ppu.cpp
+++ b/core/src/ppu.cpp
@@ -48,7 +48,8 @@ uint8_t Ppu::read_byte(uint16_t addr) {
             read_buffer_ = byte;
             byte = tmp_buffer;
         } else {
-            read_buffer_ = mmu_->read_byte(registers_->vram_addr - 0x1000);
+            read_buffer_ = mmu_->read_byte(
+                    registers_->vram_addr - static_cast<uint16_t>(0x1000));
         }
         increment_vram_address();
     } else {
@@ -64,7 +65,7 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
         // enabled (bit 7). If this is the case and we currently are in
         // vertical blanking a NMI shall be generated.
         registers_->ctrl = byte;
-        uint16_t name_table_bits = (byte & 3u);
+        auto name_table_bits = static_cast<uint16_t>(byte & 3u);
         registers_->temp_vram_addr &=
                 static_cast<uint16_t>(0b1111'0011'1111'1111);
         registers_->temp_vram_addr |=
@@ -80,7 +81,7 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
     } else if (addr == kPpuScroll) {
         if (registers_->write_toggle) { // Second write, Y scroll
             uint16_t y_scroll = (byte >> 3u);
-            uint16_t fine_y_scroll = (byte & 7u);
+            auto fine_y_scroll = static_cast<uint16_t>(byte & 7u);
             registers_->temp_vram_addr &=
                     static_cast<uint16_t>(0b1000'1100'0001'1111);
             registers_->temp_vram_addr |= static_cast<uint16_t>(y_scroll << 5u);
@@ -92,7 +93,7 @@ void Ppu::write_byte(uint16_t addr, uint8_t byte) {
             registers_->temp_vram_addr &=
                     static_cast<uint16_t>(0b1111'1111'1110'0000);
             registers_->temp_vram_addr |= x_scroll;
-            registers_->fine_x_scroll = (byte & 7u);
+            registers_->fine_x_scroll = static_cast<uint8_t>(byte & 7u);
             registers_->write_toggle = true;
         }
     } else if (addr == kPpuAddr) {

--- a/core/src/ppu.h
+++ b/core/src/ppu.h
@@ -52,7 +52,7 @@ private:
     void increment_vram_address();
 
     void execute_pre_render_scanline();
-    void execute_visible_scanline();
+    static void execute_visible_scanline();
     void execute_post_render_scanline();
     void execute_vblank_scanline();
 

--- a/core/src/rom/nrom.cpp
+++ b/core/src/rom/nrom.cpp
@@ -11,7 +11,7 @@ Nrom::Nrom(const INesHeader &h,
         : IRom(h),
           prg_rom_(std::move(prg_rom)),
           chr_rom_(std::move(chr_rom)),
-          prg_ram_(h.prg_ram_size * 8 * 1024) {
+          prg_ram_(static_cast<size_t>(h.prg_ram_size * 8 * 1024)) {
     if (prg_rom_.size() != 16 * 1024 && prg_rom_.size() != 32 * 1024) {
         throw std::invalid_argument("Invalid prg_rom size");
     }

--- a/core/src/rom_factory.cpp
+++ b/core/src/rom_factory.cpp
@@ -61,8 +61,8 @@ std::unique_ptr<IRom> RomFactory::from_bytes(std::istream &bytestream) {
     uint8_t mapper = (h.flags_6 & 0xF0u) >> 4u;
     mapper |= h.flags_7 & 0xF0u;
 
-    const uint32_t prg_rom_byte_count = h.prg_rom_size * 16 * 1024;
-    const uint32_t chr_rom_byte_count = h.chr_rom_size * 8 * 1024;
+    const auto prg_rom_byte_count = static_cast<uint32_t>(h.prg_rom_size * 16 * 1024);
+    const auto chr_rom_byte_count = static_cast<uint32_t>(h.chr_rom_size * 8 * 1024);
 
     const uint32_t expected_rom_size =
             sizeof(INesHeader) + prg_rom_byte_count + chr_rom_byte_count;

--- a/core/src/rom_factory.cpp
+++ b/core/src/rom_factory.cpp
@@ -58,11 +58,13 @@ std::unique_ptr<IRom> RomFactory::from_bytes(std::istream &bytestream) {
         h.prg_ram_size = 1; // For compatibility reasons, 0 ram means 1 ram.
     }
 
-    uint8_t mapper = (h.flags_6 & 0xF0u) >> 4u;
+    uint8_t mapper = static_cast<uint8_t>(h.flags_6 & 0xF0u) >> 4u;
     mapper |= h.flags_7 & 0xF0u;
 
-    const auto prg_rom_byte_count = static_cast<uint32_t>(h.prg_rom_size * 16 * 1024);
-    const auto chr_rom_byte_count = static_cast<uint32_t>(h.chr_rom_size * 8 * 1024);
+    const auto prg_rom_byte_count =
+            static_cast<uint32_t>(h.prg_rom_size * 16 * 1024);
+    const auto chr_rom_byte_count =
+            static_cast<uint32_t>(h.chr_rom_size * 8 * 1024);
 
     const uint32_t expected_rom_size =
             sizeof(INesHeader) + prg_rom_byte_count + chr_rom_byte_count;

--- a/core/test/src/fake_mmu.h
+++ b/core/test/src/fake_mmu.h
@@ -22,7 +22,8 @@ public:
 
     uint16_t read_word(uint16_t addr) const override {
         const uint8_t low = read_byte(addr);
-        const uint16_t upper = read_byte(addr + 1) << 8u;
+        const auto upper = static_cast<uint16_t>(
+                read_byte(addr + static_cast<uint8_t>(1)) << 8u);
         return low | upper;
     }
 
@@ -31,10 +32,10 @@ public:
     }
 
     void write_word(uint16_t addr, uint16_t word) override {
-        const uint8_t low = word & 0xFFu;
-        const uint8_t upper = word >> 8u;
+        const auto low = static_cast<uint8_t>(word & 0xFFu);
+        const auto upper = static_cast<uint8_t>(word >> 8u);
         write_byte(addr, low);
-        write_byte(addr + 1, upper);
+        write_byte(static_cast<uint16_t>(addr + 1), upper);
     }
 
 private:

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -15,7 +15,7 @@ using testing::Return;
 namespace {
 
 constexpr uint8_t u16_to_u8(uint16_t u16) {
-    return u16 % 0x100;
+    return static_cast<uint8_t>(u16 % static_cast<uint16_t>(0x100));
 }
 
 const uint16_t kStackOffset = 0x0100;
@@ -168,7 +168,7 @@ public:
             int8_t offset,
             uint8_t expected_cycles) {
         expected.p = registers.p = branch_flag;
-        expected.pc = registers.pc + 2 + offset;
+        expected.pc = registers.pc + static_cast<uint8_t>(2) + offset;
 
         EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(offset));
 
@@ -580,8 +580,10 @@ public:
         stage_instruction(instruction);
         expected.pc += 2;
 
-        const uint8_t lower_address = effective_address & 0x00FFu;
-        const uint8_t upper_address = (effective_address & 0xFF00u) >> 8u;
+        const auto lower_address = static_cast<uint8_t>(
+                effective_address & static_cast<uint16_t>(0x00FFu));
+        const auto upper_address = static_cast<uint8_t>(
+                static_cast<uint16_t>(effective_address & 0xFF00u) >> 8u);
 
         EXPECT_CALL(mmu, read_byte(start_pc + 1))
                 .WillOnce(Return(lower_address));
@@ -599,8 +601,10 @@ public:
         stage_instruction(instruction);
         expected.pc += 2;
 
-        const uint8_t lower_address = effective_address & 0x00FFu;
-        const uint8_t upper_address = (effective_address & 0xFF00u) >> 8u;
+        const auto lower_address = static_cast<uint8_t>(
+                effective_address & static_cast<uint16_t>(0x00FFu));
+        const auto upper_address =
+                static_cast<uint8_t>((effective_address & 0xFF00u) >> 8u);
 
         EXPECT_CALL(mmu, read_byte(start_pc + 1))
                 .WillOnce(Return(lower_address));
@@ -927,7 +931,7 @@ TEST_F(CpuTest, plp) {
     registers.sp = 0x0A;
     registers.p = 0xBB;
 
-    expected.sp = registers.sp + 1u;
+    expected.sp = registers.sp + static_cast<uint8_t>(1u);
     expected.p = 0x12;
 
     EXPECT_CALL(mmu, read_byte(kStackOffset + expected.sp))
@@ -951,7 +955,8 @@ TEST_F(CpuTest, jsr) {
     stage_instruction(JSR);
     expected.pc = 0xDEAD;
 
-    const uint8_t expected_pc_stack_addr = expected.sp - 1;
+    const uint8_t expected_pc_stack_addr =
+            expected.sp - static_cast<uint8_t>(1);
     expected.sp -= 2; // 1 word
 
     EXPECT_CALL(mmu, read_byte(registers.pc + 1)).WillOnce(Return(0xAD));
@@ -1421,7 +1426,7 @@ TEST_F(CpuTest, pla_sets_z_clears_n) {
     registers.a = 0xBB;
     registers.p = N_FLAG;
 
-    expected.sp = registers.sp + 1u;
+    expected.sp = registers.sp + static_cast<uint8_t>(1u);
     expected.a = 0x00;
     expected.p = Z_FLAG;
 
@@ -1438,7 +1443,7 @@ TEST_F(CpuTest, pla_sets_n_clears_z) {
     registers.a = 0xBB;
     registers.p = Z_FLAG;
 
-    expected.sp = registers.sp + 1u;
+    expected.sp = registers.sp + static_cast<uint8_t>(1u);
     expected.a = 0x92;
     expected.p = N_FLAG;
 
@@ -1481,7 +1486,7 @@ TEST_F(CpuTest, rti) {
     stage_instruction(RTI);
     registers.sp = 0x0A;
     expected.p = 0xCD;
-    expected.sp = registers.sp + 3;
+    expected.sp = registers.sp + static_cast<uint8_t>(3);
     expected.pc = 0xDEAD;
 
     // Dummy read

--- a/core/test/src/test_cpuintegration.cpp
+++ b/core/test/src/test_cpuintegration.cpp
@@ -2,7 +2,6 @@
 
 #include "fake_mmu.h"
 #include "icpu_helpers.h"
-#include "mock_mmu.h"
 
 #include <gtest/gtest.h>
 

--- a/core/test/src/test_cpuintegration.cpp
+++ b/core/test/src/test_cpuintegration.cpp
@@ -98,7 +98,8 @@ TEST_F(CpuIntegrationTest, simple_program) {
     expected.a = 0x01;
     expected.x = 0x05;
     expected.y = 0x08;
-    expected.sp = registers.sp - 3; // PC (2 bytes) + P (1 byte)
+    expected.sp =
+            registers.sp - static_cast<uint8_t>(3); // PC (2 bytes) + P (1 byte)
     expected.pc = 0xDEAD;
 
     const int expected_cycles = 2 + 4 + 2 + 4 + 2 + 4 + 7;
@@ -143,7 +144,8 @@ TEST_F(CpuIntegrationTest, branch) {
     expected.a = 0x00;
     expected.x = 0x03;
     expected.y = 0x00;
-    expected.sp = registers.sp - 3; // PC (2 bytes) + P (1 byte)
+    expected.sp =
+            registers.sp - static_cast<uint8_t>(3); // PC (2 bytes) + P (1 byte)
     expected.pc = 0xDEAD;
     expected.p = C_FLAG | Z_FLAG;
 
@@ -207,7 +209,8 @@ TEST_F(CpuIntegrationTest, stack) {
     // address before writing to it, so we need to initialize the fake mmu with
     // some data at those addresses.
     for (uint8_t i = 0; i <= 0x20; ++i) {
-        mmu.write_byte(0x0200 + i, 0xBA);
+        mmu.write_byte(
+                static_cast<uint16_t>(0x0200) + i, static_cast<uint8_t>(0xBA));
     }
 
     set_reset_address(0x0600);
@@ -215,7 +218,8 @@ TEST_F(CpuIntegrationTest, stack) {
 
     expected.x = 0x10;
     expected.y = 0x20;
-    expected.sp = registers.sp - 3; // PC (2 bytes) + P (1 byte)
+    expected.sp =
+            registers.sp - static_cast<uint8_t>(3); // PC (2 bytes) + P (1 byte)
     expected.pc = 0xDEAD;
     expected.p = C_FLAG | Z_FLAG;
 

--- a/core/test/src/test_rom.cpp
+++ b/core/test/src/test_rom.cpp
@@ -15,8 +15,9 @@ std::string ines_header_bytes(const uint8_t mapper,
         const uint8_t chr_rom_size,
         const uint8_t prg_ram_size) {
     INesHeader header{};
-    header.flags_6 = mapper & 0x0Fu << 4u;
-    header.flags_7 = mapper & 0xF0u;
+    header.flags_6 = static_cast<uint8_t>(mapper & static_cast<uint8_t>(0x0Fu))
+                     << 4u;
+    header.flags_7 = static_cast<uint8_t>(mapper & static_cast<uint8_t>(0xF0u));
     header.prg_rom_size = prg_rom_size;
     header.chr_rom_size = chr_rom_size;
     header.prg_ram_size = prg_ram_size;


### PR DESCRIPTION
Fixes various warnings reported by CLion code inspection. Went from >150 warnings to 2. The remaining 2 are due to empty implementations in ppu.cpp that it wants static - which I ignored since they will be implemented eventually.

Most warnings were due to storing temporary signed ints in smaller uint-types.