### PR TITLE
Fix compilation with gcc9+

### DIFF
--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -6,13 +6,14 @@
 namespace n_e_s::core {
 
 std::unique_ptr<IMmu> MmuFactory::create(MemBankList mem_banks) {
-    auto mmu = std::make_unique<Mmu>();
+    std::unique_ptr<IMmu> immu = std::make_unique<Mmu>();
+    auto mmu = static_cast<Mmu *>(immu.get());
 
     for (std::unique_ptr<IMemBank> &mem_bank : mem_banks) {
         mmu->add_mem_bank(std::move(mem_bank));
     }
 
-    return std::move(mmu);
+    return immu;
 }
 
 } // namespace n_e_s::core


### PR DESCRIPTION
The previous fix repaired Clang, but broke gcc 9 and 10. This should (hopefully) work with both.