### PR TITLE
Revert "Use the old VS2019 image to work around the new being broken"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,22 @@ configuration:
   - Debug
   - Release
 
+matrix:
+  allow_failures:
+    - TOOLCHAIN: Msvc 2019 x86
+    - TOOLCHAIN: Msvc 2019 x64
+
 environment:
   matrix:
   - TOOLCHAIN: Msvc 2019 x86
     GENERATOR: Visual Studio 16 2019
     CMAKE_ARGS: -A Win32
-    APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
   - TOOLCHAIN: Msvc 2019 x64
     GENERATOR: Visual Studio 16 2019
     CMAKE_ARGS: -A x64
-    APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
   - TOOLCHAIN: Msvc 2017 x64/Ninja
     GENERATOR: Ninja


### PR DESCRIPTION
This reverts commit e96daac2ac49864ddfd105fce97b4a0d602dc884.