### PR TITLE
Use read_byte in mos6502::reset()

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -488,7 +488,9 @@ void Mos6502::reset() {
     pipeline_.clear();
     nmi_ = false;
 
-    registers_->pc = mmu_->read_word(kResetAddress);
+    const uint16_t lower = mmu_->read_byte(kResetAddress);
+    const uint16_t upper = mmu_->read_byte(kResetAddress + 1u) << 8u;
+    registers_->pc = upper | lower;
 }
 
 CpuState Mos6502::state() const {

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -704,7 +704,8 @@ public:
 
 TEST_F(CpuTest, reset) {
     expected.pc = 0xDEAD;
-    EXPECT_CALL(mmu, read_word(kResetAddress)).WillOnce(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(kResetAddress)).WillOnce(Return(0xAD));
+    EXPECT_CALL(mmu, read_byte(kResetAddress + 1u)).WillOnce(Return(0xDE));
 
     cpu->reset();
 
@@ -713,7 +714,8 @@ TEST_F(CpuTest, reset) {
 
 TEST_F(CpuTest, reset_clears_pipeline) {
     stage_instruction(SEC);
-    EXPECT_CALL(mmu, read_word(kResetAddress)).WillOnce(Return(0xDEAD));
+    EXPECT_CALL(mmu, read_byte(kResetAddress)).WillOnce(Return(0xAD));
+    EXPECT_CALL(mmu, read_byte(kResetAddress + 1u)).WillOnce(Return(0xDE));
     EXPECT_CALL(mmu, read_byte(0xDEAD)).WillOnce(Return(0x00));
     expected.pc = 0xDEAD + 1;
 


### PR DESCRIPTION
* read_word will be removed in the future once all addressing modes are
  using the correct timings.