### PR TITLE
Use std::string_view for to_string(Family)

### DIFF
--- a/core/include/core/opcode.h
+++ b/core/include/core/opcode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 
 namespace n_e_s::core {
 
@@ -250,6 +250,6 @@ Opcode decode(const uint8_t op);
 
 MemoryAccess get_memory_access(const Family family);
 
-std::string to_string(const Family family);
+std::string_view to_string(const Family family);
 
 } // namespace n_e_s::core

--- a/core/src/opcode.cpp
+++ b/core/src/opcode.cpp
@@ -383,7 +383,7 @@ MemoryAccess get_memory_access(const Family family) {
     throw std::logic_error("Unknown family");
 }
 
-std::string to_string(const Family family) {
+std::string_view to_string(const Family family) {
     switch (family) {
     case Family::Invalid:
         return "Invalid";


### PR DESCRIPTION
We could also make it constexpr, but then it needs to be moved to the header