### PR TITLE
Use CMAKE_CXX_COMPILER_FRONTEND_VARIANT to detect clang variant

### DIFF
--- a/warnings/CMakeLists.txt
+++ b/warnings/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${PROJECT_NAME} INTERFACE)
 add_library(n_e_s::warnings ALIAS ${PROJECT_NAME})
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    if("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+    if("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
         set(CLANGCL ON)
     else()
         set(CLANG ON)


### PR DESCRIPTION
* This works now on Windows:
  cmake -S. -G Ninja -Bbuildclang
      -DCMAKE_C_COMPILER:PATH="c:\Program\LLVM\bin\clang.exe"
      -DCMAKE_CXX_COMPILER:PATH="c:\Program\LLVM\bin\clang.exe"
* Before, MSVC command line style was used incorrectly