### PR TITLE
Create memory for all namtables on Ppu

### DIFF
--- a/core/src/membank_base.h
+++ b/core/src/membank_base.h
@@ -10,15 +10,12 @@ namespace n_e_s::core {
 // The object will hold an array of the given size, however the specified
 // address range may be greater than the size. This is to support memory
 // mirroring, meaning that the same memory may be accessed at multiple
-// addresses. For a memory bank to be valid the difference between end and
-// start address has to be evenly dividable by the given size.
+// addresses.
 template <uint16_t StartAddr, uint16_t EndAddr, uint16_t Size>
 class MemBankBase : public IMemBank {
 public:
     static_assert(Size > 0u, "Size must be greater than zero");
     static_assert(StartAddr <= EndAddr, "Start addr greater than end addr");
-    static_assert((EndAddr - StartAddr + 1u) % Size == 0,
-            "Size does not match address range");
 
     bool is_address_in_range(uint16_t addr) const override {
         return addr >= StartAddr && addr <= EndAddr;

--- a/core/src/membank_factory.cpp
+++ b/core/src/membank_factory.cpp
@@ -47,8 +47,9 @@ MemBankList MemBankFactory::create_nes_ppu_mem_banks() {
     // $2800-$2BFF  $0400   Nametable 2
     // $2C00-$2FFF  $0400   Nametable 3
     // $3000-$3EFF  $0F00   Mirrors of $2000-$2EFF
-    // TODO(JN), fix mirroring at 0x3000 - 0x3EFF
-    mem_banks.push_back(std::make_unique<MemBank<0x2000, 0x2FFF, 0x0400>>());
+    mem_banks.push_back(std::make_unique<MemBank<0x2000, 0x3EFF, 0x1000>>());
+
+    // Palettes
     mem_banks.push_back(std::make_unique<MemBank<0x3F00, 0x3FFF, 0x20>>());
 
     return mem_banks;

--- a/core/test/src/test_ppu_membank.cpp
+++ b/core/test/src/test_ppu_membank.cpp
@@ -16,6 +16,34 @@ public:
     std::unique_ptr<IMmu> mmu;
 };
 
+// Nametables
+TEST_F(PpuMembankTest, the_nametable_memory_works) {
+    mmu->write_byte(0x2000, 0x42);
+    EXPECT_EQ(0x42, mmu->read_byte(0x2000));
+    mmu->write_byte(0x2FFF, 0x39);
+    EXPECT_EQ(0x39, mmu->read_byte(0x2FFF));
+    EXPECT_EQ(0x42, mmu->read_byte(0x2000));
+}
+
+TEST_F(PpuMembankTest, the_nametable_memory_is_mirrored) {
+    const auto nametable_size = 0x400 * 4;
+    mmu->write_byte(0x2000, 0x01);
+    for (uint16_t addr = 0x2000; addr < 0x3EFF; addr += nametable_size) {
+        EXPECT_EQ(0x01, mmu->read_byte(addr));
+    }
+
+    mmu->write_byte(0x2EFA, 0x07);
+    for (uint16_t addr = 0x2EFA; addr < 0x3EFF; addr += nametable_size) {
+        EXPECT_EQ(0x07, mmu->read_byte(addr));
+    }
+
+    // Mirror of nametable 3 is smaller than the size of a nametable,
+    // so the memory between 0x3F00 and 0x3FFF should not be mirrored.
+    for (uint16_t addr = 0x3F00; addr < 0x4000; ++addr) {
+        EXPECT_EQ(0x00, mmu->read_byte(addr));
+    }
+}
+
 // Palette memory
 TEST_F(PpuMembankTest, the_palette_memory_works) {
     mmu->write_byte(0x3F00, 0x42);


### PR DESCRIPTION
* The mirrored memory for nametables is not the same size as the main
  memory. Had to remove condition that the address range is evenly
  dividable by the size.