### PR TITLE
Enable nametable mirroring

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${PROJECT_NAME}
     include/nes/core/imembank.h
     include/nes/core/immu.h
     include/nes/core/imos6502.h
+    include/nes/core/ines_header.h
     include/nes/core/invalid_address.h
     include/nes/core/ippu.h
     include/nes/core/irom.h

--- a/core/include/nes/core/immu.h
+++ b/core/include/nes/core/immu.h
@@ -2,11 +2,17 @@
 
 #include <cstdint>
 
+#include "nes/core/imembank.h"
+
 namespace n_e_s::core {
+
+class IMemBank;
 
 class IMmu {
 public:
     virtual ~IMmu() = default;
+
+    virtual void set_mem_banks(MemBankList mem_banks) = 0;
 
     virtual uint8_t read_byte(uint16_t addr) const = 0;
     virtual void write_byte(uint16_t addr, uint8_t byte) = 0;

--- a/core/include/nes/core/ines_header.h
+++ b/core/include/nes/core/ines_header.h
@@ -4,6 +4,8 @@
 
 namespace n_e_s::core {
 
+enum class Mirroring { Horizontal, Vertical };
+
 struct INesHeader {
     uint8_t nes[4]{'N', 'E', 'S', 26}; // NES + MS-DOS EOF
     uint8_t prg_rom_size; // in 16 KB units.
@@ -14,6 +16,16 @@ struct INesHeader {
     uint8_t flags_9;
     uint8_t flags_10;
     uint8_t zeros[5]{0};
+
+    [[nodiscard]] constexpr uint8_t mapper() const {
+        uint8_t mapper = static_cast<uint8_t>(flags_6 & 0xF0u) >> 4u;
+        mapper |= flags_7 & 0xF0u;
+        return mapper;
+    }
+
+    [[nodiscard]] constexpr Mirroring mirroring() const {
+        return flags_6 & 0x01u ? Mirroring::Vertical : Mirroring::Horizontal;
+    }
 };
 
 } // namespace n_e_s::core

--- a/core/include/nes/core/ines_header.h
+++ b/core/include/nes/core/ines_header.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace n_e_s::core {
+
+struct INesHeader {
+    uint8_t nes[4]{'N', 'E', 'S', 26}; // NES + MS-DOS EOF
+    uint8_t prg_rom_size; // in 16 KB units.
+    uint8_t chr_rom_size; // in 8 KB units.
+    uint8_t flags_6;
+    uint8_t flags_7;
+    uint8_t prg_ram_size; // in 8 KB units.
+    uint8_t flags_9;
+    uint8_t flags_10;
+    uint8_t zeros[5]{0};
+};
+
+} // namespace n_e_s::core

--- a/core/include/nes/core/irom.h
+++ b/core/include/nes/core/irom.h
@@ -1,13 +1,22 @@
 #pragma once
 
-#include "nes/core/imembank.h"
 #include "nes/core/ines_header.h"
 
 namespace n_e_s::core {
 
-class IRom : public IMemBank {
+class IRom {
 public:
     explicit IRom(const INesHeader &h) : header_(h) {}
+
+    virtual ~IRom() = default;
+
+    [[nodiscard]] virtual bool is_cpu_address_in_range(uint16_t addr) const = 0;
+    [[nodiscard]] virtual uint8_t cpu_read_byte(uint16_t addr) const = 0;
+    virtual void cpu_write_byte(uint16_t addr, uint8_t byte) = 0;
+
+    [[nodiscard]] virtual bool is_ppu_address_in_range(uint16_t addr) const = 0;
+    [[nodiscard]] virtual uint8_t ppu_read_byte(uint16_t addr) const = 0;
+    virtual void ppu_write_byte(uint16_t addr, uint8_t byte) = 0;
 
 private:
     INesHeader header_;

--- a/core/include/nes/core/irom.h
+++ b/core/include/nes/core/irom.h
@@ -18,6 +18,10 @@ public:
     [[nodiscard]] virtual uint8_t ppu_read_byte(uint16_t addr) const = 0;
     virtual void ppu_write_byte(uint16_t addr, uint8_t byte) = 0;
 
+    const INesHeader &header() const {
+        return header_;
+    }
+
 private:
     INesHeader header_;
 };

--- a/core/include/nes/core/irom.h
+++ b/core/include/nes/core/irom.h
@@ -1,22 +1,9 @@
 #pragma once
 
 #include "nes/core/imembank.h"
-
-#include <cstdint>
+#include "nes/core/ines_header.h"
 
 namespace n_e_s::core {
-
-struct INesHeader {
-    uint8_t nes[4]{'N', 'E', 'S', 26}; // NES + MS-DOS EOF
-    uint8_t prg_rom_size; // in 16 KB units.
-    uint8_t chr_rom_size; // in 8 KB units.
-    uint8_t flags_6;
-    uint8_t flags_7;
-    uint8_t prg_ram_size; // in 8 KB units.
-    uint8_t flags_9;
-    uint8_t flags_10;
-    uint8_t zeros[5]{0};
-};
 
 class IRom : public IMemBank {
 public:

--- a/core/include/nes/core/membank_factory.h
+++ b/core/include/nes/core/membank_factory.h
@@ -1,15 +1,17 @@
 #pragma once
 
 #include "nes/core/imembank.h"
-#include "nes/core/ippu.h"
 
 namespace n_e_s::core {
 
+class IPpu;
+class IRom;
+
 class MemBankFactory {
 public:
-    [[nodiscard]] static MemBankList create_nes_mem_banks(IPpu *ppu);
+    [[nodiscard]] static MemBankList create_nes_mem_banks(IPpu *ppu, IRom *rom);
 
-    [[nodiscard]] static MemBankList create_nes_ppu_mem_banks();
+    [[nodiscard]] static MemBankList create_nes_ppu_mem_banks(IRom *rom);
 };
 
 } // namespace n_e_s::core

--- a/core/include/nes/core/mmu_factory.h
+++ b/core/include/nes/core/mmu_factory.h
@@ -9,6 +9,8 @@ namespace n_e_s::core {
 
 class MmuFactory {
 public:
+    [[nodiscard]] static std::unique_ptr<IMmu> create_empty();
+
     [[nodiscard]] static std::unique_ptr<IMmu> create(MemBankList mem_banks);
 };
 

--- a/core/src/membank_factory.cpp
+++ b/core/src/membank_factory.cpp
@@ -1,12 +1,48 @@
 #include "nes/core/membank_factory.h"
 
-#include "nes/core/ippu.h"
+#include <memory>
 
 #include "mapped_membank.h"
 #include "membank.h"
+#include "nes/core/ippu.h"
+#include "nes/core/irom.h"
 
 namespace n_e_s::core {
 namespace {
+
+class CpuRomTranslator : public IMemBank {
+public:
+    explicit CpuRomTranslator(IRom *const rom) : rom_(rom) {}
+    bool is_address_in_range(uint16_t addr) const override {
+        return rom_->is_cpu_address_in_range(addr);
+    }
+    uint8_t read_byte(uint16_t addr) const override {
+        return rom_->cpu_read_byte(addr);
+    }
+    void write_byte(uint16_t addr, uint8_t byte) override {
+        rom_->cpu_write_byte(addr, byte);
+    }
+
+private:
+    IRom *rom_;
+};
+
+class PpuRomTranslator : public IMemBank {
+public:
+    explicit PpuRomTranslator(IRom *const rom) : rom_(rom) {}
+    bool is_address_in_range(uint16_t addr) const override {
+        return rom_->is_ppu_address_in_range(addr);
+    }
+    uint8_t read_byte(uint16_t addr) const override {
+        return rom_->ppu_read_byte(addr);
+    }
+    void write_byte(uint16_t addr, uint8_t byte) override {
+        rom_->ppu_write_byte(addr, byte);
+    }
+
+private:
+    IRom *rom_;
+};
 
 auto create_ppu_reader(IPpu *ppu) {
     return [ppu](uint16_t addr) { return ppu->read_byte(addr); };
@@ -18,8 +54,12 @@ auto create_ppu_writer(IPpu *ppu) {
 
 } // namespace
 
-MemBankList MemBankFactory::create_nes_mem_banks(IPpu *ppu) {
+MemBankList MemBankFactory::create_nes_mem_banks(IPpu *ppu, IRom *rom) {
     MemBankList mem_banks;
+
+    // Rom, make sure this is first so the mapper can decide if it wants to
+    // handle the address or not.
+    mem_banks.push_back(std::make_unique<CpuRomTranslator>(rom));
 
     // Ram, repeats every 0x800 byte
     mem_banks.push_back(std::make_unique<MemBank<0x0000, 0x1FFF, 0x800>>());
@@ -37,8 +77,12 @@ MemBankList MemBankFactory::create_nes_mem_banks(IPpu *ppu) {
     return mem_banks;
 }
 
-MemBankList MemBankFactory::create_nes_ppu_mem_banks() {
+MemBankList MemBankFactory::create_nes_ppu_mem_banks(IRom *rom) {
     MemBankList mem_banks;
+
+    // Rom, make sure this is first so the mapper can decide if it wants to
+    // handle the address or not.
+    mem_banks.push_back(std::make_unique<PpuRomTranslator>(rom));
 
     // Nametables
     // Range        Size    Desc

--- a/core/src/membank_factory.cpp
+++ b/core/src/membank_factory.cpp
@@ -84,15 +84,7 @@ MemBankList MemBankFactory::create_nes_ppu_mem_banks(IRom *rom) {
     // handle the address or not.
     mem_banks.push_back(std::make_unique<PpuRomTranslator>(rom));
 
-    // Nametables
-    // Range        Size    Desc
-    // $2000-$23FF  $0400   Nametable 0
-    // $2400-$27FF  $0400   Nametable 1
-    // $2800-$2BFF  $0400   Nametable 2
-    // $2C00-$2FFF  $0400   Nametable 3
-    // $3000-$3EFF  $0F00   Mirrors of $2000-$2EFF
-    // TODO(JN), fix mirroring at 0x3000 - 0x3EFF
-    mem_banks.push_back(std::make_unique<MemBank<0x2000, 0x2FFF, 0x0400>>());
+    // Palettes
     mem_banks.push_back(std::make_unique<MemBank<0x3F00, 0x3FFF, 0x20>>());
 
     return mem_banks;

--- a/core/src/mmu.cpp
+++ b/core/src/mmu.cpp
@@ -18,8 +18,16 @@ auto equal(uint16_t addr) {
 
 Mmu::Mmu() : mem_banks_() {}
 
+void Mmu::clear() {
+    mem_banks_.clear();
+}
+
 void Mmu::add_mem_bank(std::unique_ptr<IMemBank> mem_bank) {
     mem_banks_.push_back(std::move(mem_bank));
+}
+
+void Mmu::set_mem_banks(MemBankList mem_banks) {
+    mem_banks_ = std::move(mem_banks);
 }
 
 IMemBank *Mmu::get_mem_bank(uint16_t addr) const {

--- a/core/src/mmu.h
+++ b/core/src/mmu.h
@@ -13,7 +13,10 @@ class Mmu final : public IMmu {
 public:
     Mmu();
 
+    void clear();
+
     void add_mem_bank(std::unique_ptr<IMemBank> mem_bank);
+    void set_mem_banks(MemBankList mem_banks) override;
 
     uint8_t read_byte(uint16_t addr) const override;
     void write_byte(uint16_t addr, uint8_t byte) override;

--- a/core/src/mmu_factory.cpp
+++ b/core/src/mmu_factory.cpp
@@ -5,6 +5,10 @@
 
 namespace n_e_s::core {
 
+std::unique_ptr<IMmu> MmuFactory::create_empty() {
+    return std::make_unique<Mmu>();
+}
+
 std::unique_ptr<IMmu> MmuFactory::create(MemBankList mem_banks) {
     std::unique_ptr<IMmu> immu = std::make_unique<Mmu>();
     auto mmu = static_cast<Mmu *>(immu.get());

--- a/core/src/rom/nrom.cpp
+++ b/core/src/rom/nrom.cpp
@@ -2,6 +2,8 @@
 
 #include <cassert>
 #include <stdexcept>
+#include <string>
+#include "nes/core/ines_header.h"
 
 namespace n_e_s::core {
 
@@ -11,7 +13,8 @@ Nrom::Nrom(const INesHeader &h,
         : IRom(h),
           prg_rom_(std::move(prg_rom)),
           chr_rom_(std::move(chr_rom)),
-          prg_ram_(static_cast<size_t>(h.prg_ram_size * 8 * 1024)) {
+          prg_ram_(static_cast<size_t>(h.prg_ram_size * 8 * 1024)),
+          nametables_{} {
     if (prg_rom_.size() != 16 * 1024 && prg_rom_.size() != 32 * 1024) {
         throw std::invalid_argument("Invalid prg_rom size");
     }
@@ -29,34 +32,89 @@ bool Nrom::is_cpu_address_in_range(uint16_t addr) const {
 uint8_t Nrom::cpu_read_byte(uint16_t addr) const {
     if (addr <= kPrgRamEnd) {
         addr -= kPrgRamStart;
-        return prg_ram_.at(addr);
+        return prg_ram_[addr % prg_ram_.size()];
     }
 
     addr -= kPrgRomStart;
-    return prg_rom_.at(addr);
+    return prg_rom_[addr % prg_rom_.size()];
 }
 
 void Nrom::cpu_write_byte(uint16_t addr, uint8_t byte) {
     if (addr <= kPrgRamEnd) {
         addr -= kPrgRamStart;
-        prg_ram_.at(addr) = byte;
+        prg_ram_[addr % prg_ram_.size()] = byte;
     }
 
     addr -= kPrgRomStart;
-    prg_rom_.at(addr) = byte;
+    prg_rom_[addr % prg_rom_.size()] = byte;
 }
 
 bool Nrom::is_ppu_address_in_range(uint16_t addr) const {
     const bool in_chr = addr <= kChrEnd;
-    return in_chr;
+    const bool in_nametable = addr >= kNametableStart && addr <= kNametableEnd;
+    return in_chr || in_nametable;
 }
 
 uint8_t Nrom::ppu_read_byte(uint16_t addr) const {
-    return chr_rom_.at(addr);
+    if (addr <= kChrEnd) {
+        return chr_rom_.at(addr);
+    }
+    const auto [index, addr_mod] =
+            translate_nametable_addr(addr, header().mirroring());
+    return nametables_[index][addr_mod];
 }
 
 void Nrom::ppu_write_byte(uint16_t addr, uint8_t byte) {
-    chr_rom_.at(addr) = byte;
+    if (addr <= kChrEnd) {
+        chr_rom_.at(addr) = byte;
+    }
+    const auto [index, addr_mod] =
+            translate_nametable_addr(addr, header().mirroring());
+    nametables_[index][addr_mod] = byte;
+}
+
+std::pair<int, uint16_t> Nrom::translate_nametable_addr(uint16_t addr,
+        Mirroring m) const {
+    // Nametables
+    // Range        Size    Desc
+    // $2000-$23FF  $0400   Nametable 0
+    // $2400-$27FF  $0400   Nametable 1
+    // $2800-$2BFF  $0400   Nametable 2
+    // $2C00-$2FFF  $0400   Nametable 3
+    // $3000-$3EFF  $0F00   Mirrors of $2000-$2EFF
+
+    // Ignore top 4 bits to handle mirroring
+    addr &= 0x0FFFu;
+    if (m == Mirroring::Horizontal) {
+        // Nametable 0 and 1 should be the same
+        if (addr <= 0x03FF) {
+            return {0, addr % 0x0400};
+        }
+        if (addr >= 0x0400 && addr <= 0x07FF) {
+            return {0, addr % 0x0400};
+        }
+        if (addr >= 0x0800 && addr <= 0x0BFF) {
+            return {1, addr % 0x0400};
+        }
+        if (addr >= 0x0C00 && addr <= 0x0FFF) {
+            return {1, addr % 0x0400};
+        }
+    } else if (header().mirroring() == Mirroring::Vertical) {
+        // Nametable 0 and 3 should be the same
+        if (addr <= 0x03FF) {
+            return {0, addr % 0x0400};
+        }
+        if (addr >= 0x0400 && addr <= 0x07FF) {
+            return {1, addr % 0x0400};
+        }
+        if (addr >= 0x0800 && addr <= 0x0BFF) {
+            return {0, addr % 0x0400};
+        }
+        if (addr >= 0x0C00 && addr <= 0x0FFF) {
+            return {1, addr % 0x0400};
+        }
+    }
+    throw std::runtime_error("Unknown address: " + std::to_string(addr));
 }
 
 } // namespace n_e_s::core

--- a/core/src/rom/nrom.h
+++ b/core/src/rom/nrom.h
@@ -12,14 +12,15 @@ public:
             std::vector<uint8_t> prg_rom,
             std::vector<uint8_t> chr_rom);
 
-    bool is_address_in_range(uint16_t addr) const override;
-    uint8_t read_byte(uint16_t addr) const override;
-    void write_byte(uint16_t addr, uint8_t byte) override;
+    [[nodiscard]] bool is_cpu_address_in_range(uint16_t addr) const override;
+    uint8_t cpu_read_byte(uint16_t addr) const override;
+    void cpu_write_byte(uint16_t addr, uint8_t byte) override;
+
+    [[nodiscard]] bool is_ppu_address_in_range(uint16_t addr) const override;
+    uint8_t ppu_read_byte(uint16_t addr) const override;
+    void ppu_write_byte(uint16_t addr, uint8_t byte) override;
 
 private:
-    std::vector<uint8_t> &translate_address(uint16_t addr);
-    const std::vector<uint8_t> &translate_address(uint16_t addr) const;
-
     std::vector<uint8_t> prg_rom_; // const?
     std::vector<uint8_t> chr_rom_; // const?
     std::vector<uint8_t> prg_ram_;

--- a/core/src/rom/nrom.h
+++ b/core/src/rom/nrom.h
@@ -2,6 +2,7 @@
 
 #include "nes/core/irom.h"
 
+#include <array>
 #include <vector>
 
 namespace n_e_s::core {
@@ -21,11 +22,19 @@ public:
     void ppu_write_byte(uint16_t addr, uint8_t byte) override;
 
 private:
+    std::pair<int, uint16_t> translate_nametable_addr(uint16_t addr,
+            Mirroring m) const;
+
     std::vector<uint8_t> prg_rom_; // const?
     std::vector<uint8_t> chr_rom_; // const?
     std::vector<uint8_t> prg_ram_;
 
+    std::array<std::array<uint8_t, 0x0400>, 2> nametables_;
+
     constexpr static uint16_t kChrEnd{0x1FFF};
+    constexpr static uint16_t kNametableStart{0x2000};
+    constexpr static uint16_t kNametableEnd{0x3EFF};
+
     constexpr static uint16_t kPrgRamStart{0x6000};
     constexpr static uint16_t kPrgRamEnd{0x7FFF};
     constexpr static uint16_t kPrgRomStart{0x8000};

--- a/core/src/rom_factory.cpp
+++ b/core/src/rom_factory.cpp
@@ -7,9 +7,12 @@
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 static_assert(sizeof(n_e_s::core::INesHeader) == 16);
+static_assert(std::is_trivially_copyable<n_e_s::core::INesHeader>::value,
+        "INesHeader must be trivially copyable for memcpy to work");
 
 namespace {
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(${PROJECT_NAME}
     src/test_cpu_zeropage_indexed_instructions.cpp
     src/test_cpu_zeropage_instructions.cpp
     src/test_cpuintegration.cpp
+    src/test_ines_header.cpp
     src/test_invalid_address.cpp
     src/test_mmu.cpp
     src/test_opcode.cpp

--- a/core/test/src/mock_irom.h
+++ b/core/test/src/mock_irom.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "nes/core/irom.h"
+
+#include <gmock/gmock.h>
+
+namespace n_e_s::core::test {
+
+class MockIRom : public IRom {
+public:
+    MockIRom() : IRom(INesHeader()) {}
+
+    MOCK_METHOD(bool,
+            is_cpu_address_in_range,
+            (uint16_t addr),
+            (const, override));
+    MOCK_METHOD(uint8_t, cpu_read_byte, (uint16_t addr), (const, override));
+    MOCK_METHOD(void,
+            cpu_write_byte,
+            (uint16_t addr, uint8_t byte),
+            (override));
+
+    MOCK_METHOD(bool,
+            is_ppu_address_in_range,
+            (uint16_t addr),
+            (const, override));
+    MOCK_METHOD(uint8_t, ppu_read_byte, (uint16_t addr), (const, override));
+    MOCK_METHOD(void,
+            ppu_write_byte,
+            (uint16_t addr, uint8_t byte),
+            (override));
+};
+
+} // namespace n_e_s::core::test

--- a/core/test/src/test_ines_header.cpp
+++ b/core/test/src/test_ines_header.cpp
@@ -1,0 +1,27 @@
+#include "nes/core/ines_header.h"
+
+#include <gtest/gtest.h>
+
+using namespace n_e_s::core;
+
+namespace {
+
+TEST(INesHeader, returns_correct_mapper) {
+    INesHeader h;
+    h.flags_6 = 0b0011'0000;
+    h.flags_7 = 0b1010'0000;
+    EXPECT_EQ(0b1010'0011, h.mapper());
+}
+
+TEST(INesHeader, returns_horizonal_mirroring) {
+    INesHeader h;
+    h.flags_6 = 0x00;
+    EXPECT_EQ(Mirroring::Horizontal, h.mirroring());
+}
+TEST(INesHeader, returns_vertical_mirroring) {
+    INesHeader h;
+    h.flags_6 = 0x01;
+    EXPECT_EQ(Mirroring::Vertical, h.mirroring());
+}
+
+} // namespace

--- a/core/test/src/test_mmu.cpp
+++ b/core/test/src/test_mmu.cpp
@@ -2,6 +2,7 @@
 #include "nes/core/membank_factory.h"
 #include "nes/core/mmu_factory.h"
 
+#include "mock_irom.h"
 #include "nes/core/test/mock_ppu.h"
 
 #include <gtest/gtest.h>
@@ -19,10 +20,12 @@ class MmuTest : public ::testing::Test {
 public:
     MmuTest()
             : ppu{},
+              rom{},
               mmu{MmuFactory::create(
-                      MemBankFactory::create_nes_mem_banks(&ppu))} {}
+                      MemBankFactory::create_nes_mem_banks(&ppu, &rom))} {}
 
     MockPpu ppu;
+    MockIRom rom;
     std::unique_ptr<IMmu> mmu;
 };
 

--- a/core/test/src/test_mmu.cpp
+++ b/core/test/src/test_mmu.cpp
@@ -1,11 +1,14 @@
+#include "nes/core/imembank.h"
 #include "nes/core/invalid_address.h"
 #include "nes/core/membank_factory.h"
 #include "nes/core/mmu_factory.h"
 
 #include "mock_irom.h"
+#include "nes/core/test/mock_membank.h"
 #include "nes/core/test/mock_ppu.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 
 using namespace n_e_s::core;
 using namespace n_e_s::core::test;
@@ -16,9 +19,9 @@ std::vector<uint16_t> get_addr_list() {
     return {0x0000, 0x1000, 0x4000};
 }
 
-class MmuTest : public ::testing::Test {
+class NesMmuTest : public ::testing::Test {
 public:
-    MmuTest()
+    NesMmuTest()
             : ppu{},
               rom{},
               mmu{MmuFactory::create(
@@ -29,14 +32,14 @@ public:
     std::unique_ptr<IMmu> mmu;
 };
 
-class MmuInvalidAddressTest : public ::testing::Test {
+class MmuTest : public ::testing::Test {
 public:
-    MmuInvalidAddressTest() : mmu{MmuFactory::create(MemBankList())} {}
+    MmuTest() : mmu{MmuFactory::create(MemBankList())} {}
 
     std::unique_ptr<IMmu> mmu;
 };
 
-TEST_F(MmuTest, read_write_byte) {
+TEST_F(NesMmuTest, read_write_byte) {
     const uint8_t byte = 0xF0;
 
     for (uint16_t addr : get_addr_list()) {
@@ -45,7 +48,7 @@ TEST_F(MmuTest, read_write_byte) {
     }
 }
 
-TEST_F(MmuTest, read_write_byte_to_ppu) {
+TEST_F(NesMmuTest, read_write_byte_to_ppu) {
     const uint8_t byte = 0xAB;
 
     EXPECT_CALL(ppu, write_byte(0x2000, 0xAB));
@@ -59,12 +62,12 @@ TEST_F(MmuTest, read_write_byte_to_ppu) {
     EXPECT_EQ(byte, mmu->read_byte(0x3000));
 }
 
-TEST_F(MmuTest, read_write_byte_io_dev_bank) {
+TEST_F(NesMmuTest, read_write_byte_io_dev_bank) {
     mmu->write_byte(0x4018, 0x33);
     EXPECT_EQ(0x33, mmu->read_byte(0x4018));
 }
 
-TEST_F(MmuTest, ram_bank_mirroring) {
+TEST_F(NesMmuTest, ram_bank_mirroring) {
     const std::vector<uint16_t> addrs{0x100, 0x900, 0x1100, 0x1900};
     const std::vector<uint8_t> bytes{0x1F, 0xCC, 0x01, 0xAB};
 
@@ -77,12 +80,26 @@ TEST_F(MmuTest, ram_bank_mirroring) {
     }
 }
 
-TEST_F(MmuInvalidAddressTest, read_byte_invalid_address) {
+TEST_F(MmuTest, read_byte_invalid_address) {
     EXPECT_THROW(mmu->read_byte(0x3333), InvalidAddress);
 }
 
-TEST_F(MmuInvalidAddressTest, write_byte_invalid_address) {
+TEST_F(MmuTest, write_byte_invalid_address) {
     EXPECT_THROW(mmu->write_byte(0x1234, 0xFF), InvalidAddress);
+}
+
+TEST_F(MmuTest, set_membanks) {
+    auto mem_bank = std::make_unique<MockMemBank>();
+
+    EXPECT_CALL(*mem_bank, write_byte(1234u, 42u));
+    EXPECT_CALL(*mem_bank, is_address_in_range(1234u))
+            .WillOnce(testing::Return(true));
+
+    MemBankList mem_banks;
+    mem_banks.emplace_back(std::move(mem_bank));
+    mmu->set_mem_banks(std::move(mem_banks));
+
+    mmu->write_byte(1234u, 42u);
 }
 
 } // namespace

--- a/core/test/src/test_ppu_membank.cpp
+++ b/core/test/src/test_ppu_membank.cpp
@@ -1,6 +1,8 @@
 #include "nes/core/membank_factory.h"
 #include "nes/core/mmu_factory.h"
 
+#include "mock_irom.h"
+
 #include <gtest/gtest.h>
 
 using namespace n_e_s::core;
@@ -10,9 +12,11 @@ namespace {
 class PpuMembankTest : public ::testing::Test {
 public:
     PpuMembankTest()
-            : mmu{MmuFactory::create(
-                      MemBankFactory::create_nes_ppu_mem_banks())} {}
+            : rom{},
+              mmu{MmuFactory::create(
+                      MemBankFactory::create_nes_ppu_mem_banks(&rom))} {}
 
+    test::MockIRom rom;
     std::unique_ptr<IMmu> mmu;
 };
 

--- a/core/test/src/test_rom.cpp
+++ b/core/test/src/test_rom.cpp
@@ -76,14 +76,20 @@ TEST(Nrom, creation_works_with_correct_rom_sizes) {
     EXPECT_NE(nullptr, nrom);
 }
 
-TEST(Nrom, has_the_correct_address_space) {
+TEST(Nrom, has_the_correct_cpu_address_space) {
     std::string bytes{nrom_bytes(1, 1)};
     std::stringstream ss(bytes);
     std::unique_ptr<IRom> nrom{RomFactory::from_bytes(ss)};
-    EXPECT_TRUE(nrom->is_address_in_range(0x0000));
-    EXPECT_TRUE(nrom->is_address_in_range(0x1FFF));
-    EXPECT_TRUE(nrom->is_address_in_range(0x6000));
-    EXPECT_TRUE(nrom->is_address_in_range(0xFFFF));
+    EXPECT_TRUE(nrom->is_cpu_address_in_range(0x6000));
+    EXPECT_TRUE(nrom->is_cpu_address_in_range(0xFFFF));
+}
+
+TEST(Nrom, has_the_correct_ppu_address_space) {
+    std::string bytes{nrom_bytes(1, 1)};
+    std::stringstream ss(bytes);
+    std::unique_ptr<IRom> nrom{RomFactory::from_bytes(ss)};
+    EXPECT_TRUE(nrom->is_ppu_address_in_range(0x0000));
+    EXPECT_TRUE(nrom->is_ppu_address_in_range(0x1FFF));
 }
 
 TEST(Nrom, creation_fails_with_bad_rom_sizes) {
@@ -109,23 +115,29 @@ TEST(Nrom, creation_fails_with_bad_rom_sizes) {
     EXPECT_THROW(auto tmp = RomFactory::from_bytes(ss), std::invalid_argument);
 }
 
-TEST(Nrom, write_and_read_byte) {
+TEST(Nrom, write_and_read_byte_ppu_bus) {
     std::string bytes{nrom_bytes(1, 1)};
     std::stringstream ss(bytes);
     std::unique_ptr<IRom> nrom = RomFactory::from_bytes(ss);
 
-    nrom->write_byte(0x0100, 0x89);
-    EXPECT_EQ(0x89, nrom->read_byte(0x0100));
+    nrom->ppu_write_byte(0x0100, 0x89);
+    EXPECT_EQ(0x89, nrom->ppu_read_byte(0x0100));
+}
 
-    nrom->write_byte(0x6000, 0x0F);
-    EXPECT_EQ(0x0F, nrom->read_byte(0x6000));
+TEST(Nrom, write_and_read_byte_cpu_bus) {
+    std::string bytes{nrom_bytes(1, 1)};
+    std::stringstream ss(bytes);
+    std::unique_ptr<IRom> nrom = RomFactory::from_bytes(ss);
 
-    nrom->write_byte(0x8000, 0xAB);
-    EXPECT_EQ(0xAB, nrom->read_byte(0x8000));
-    EXPECT_EQ(0xAB, nrom->read_byte(0xC000));
-    nrom->write_byte(0xBFFF, 0x10);
-    EXPECT_EQ(0x10, nrom->read_byte(0xBFFF));
-    EXPECT_EQ(0x10, nrom->read_byte(0xFFFF));
+    nrom->cpu_write_byte(0x6000, 0x0F);
+    EXPECT_EQ(0x0F, nrom->cpu_read_byte(0x6000));
+
+    nrom->cpu_write_byte(0x8000, 0xAB);
+    EXPECT_EQ(0xAB, nrom->cpu_read_byte(0x8000));
+    EXPECT_EQ(0xAB, nrom->cpu_read_byte(0xC000));
+    nrom->cpu_write_byte(0xBFFF, 0x10);
+    EXPECT_EQ(0x10, nrom->cpu_read_byte(0xBFFF));
+    EXPECT_EQ(0x10, nrom->cpu_read_byte(0xFFFF));
 }
 
 } // namespace

--- a/core/test_utils/include/nes/core/test/fake_mmu.h
+++ b/core/test_utils/include/nes/core/test/fake_mmu.h
@@ -11,6 +11,8 @@ namespace n_e_s::core::test {
 
 class FakeMmu : public IMmu {
 public:
+    void set_mem_banks(MemBankList) override {}
+
     uint8_t read_byte(uint16_t addr) const override {
         if (const auto iter = memory_.find(addr); iter != memory_.end()) {
             return iter->second;

--- a/core/test_utils/include/nes/core/test/mock_mmu.h
+++ b/core/test_utils/include/nes/core/test/mock_mmu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "nes/core/imembank.h"
 #include "nes/core/immu.h"
 
 #include <gmock/gmock.h>
@@ -8,6 +9,8 @@ namespace n_e_s::core::test {
 
 class MockMmu : public IMmu {
 public:
+    MOCK_METHOD(void, set_mem_banks, (MemBankList mem_banks), (override));
+
     MOCK_METHOD(uint8_t, read_byte, (uint16_t addr), (const, override));
     MOCK_METHOD(void, write_byte, (uint16_t addr, uint8_t byte), (override));
 };

--- a/nes/include/nes/nes.h
+++ b/nes/include/nes/nes.h
@@ -11,6 +11,8 @@ class IPpu;
 struct PpuRegisters;
 
 class IMmu;
+
+class IRom;
 } // namespace n_e_s::core
 
 namespace n_e_s::nes {
@@ -53,6 +55,8 @@ private:
 
     std::unique_ptr<n_e_s::core::CpuRegisters> cpu_registers_;
     std::unique_ptr<n_e_s::core::IMos6502> cpu_;
+
+    std::unique_ptr<n_e_s::core::IRom> rom_;
 
     uint64_t cycle_{};
 };

--- a/nes/src/nes.cpp
+++ b/nes/src/nes.cpp
@@ -37,12 +37,10 @@ private:
 } // namespace
 
 Nes::Nes()
-        : ppu_mmu_(MmuFactory::create(
-                  MemBankFactory::create_nes_ppu_mem_banks())),
+        : ppu_mmu_(MmuFactory::create_empty()),
           ppu_registers_(std::make_unique<n_e_s::core::PpuRegisters>()),
           ppu_(PpuFactory::create(ppu_registers_.get(), ppu_mmu_.get())),
-          mmu_(MmuFactory::create(
-                  MemBankFactory::create_nes_mem_banks(ppu_.get()))),
+          mmu_(MmuFactory::create_empty()),
           cpu_registers_(std::make_unique<n_e_s::core::CpuRegisters>()),
           cpu_(CpuFactory::create_mos6502(cpu_registers_.get(),
                   mmu_.get(),
@@ -75,16 +73,11 @@ void Nes::load_rom(const std::string &filepath) {
     MemBankList ppu_membanks{MemBankFactory::create_nes_ppu_mem_banks()};
 
     ppu_membanks.push_back(std::make_unique<MemBankReference>(rom.get()));
-
-    ppu_mmu_ = MmuFactory::create(std::move(ppu_membanks));
-    ppu_ = PpuFactory::create(ppu_registers_.get(), ppu_mmu_.get());
+    ppu_mmu_->set_mem_banks(std::move(ppu_membanks));
 
     MemBankList cpu_membanks{MemBankFactory::create_nes_mem_banks(ppu_.get())};
     cpu_membanks.push_back(std::move(rom));
-
-    mmu_ = MmuFactory::create(std::move(cpu_membanks));
-    cpu_ = CpuFactory::create_mos6502(
-            cpu_registers_.get(), mmu_.get(), ppu_.get());
+    mmu_->set_mem_banks(std::move(cpu_membanks));
 
     reset();
 }

--- a/nes/src/nes.cpp
+++ b/nes/src/nes.cpp
@@ -68,15 +68,14 @@ void Nes::reset() {
 }
 
 void Nes::load_rom(const std::string &filepath) {
-    std::unique_ptr<IRom> rom{RomFactory::from_file(filepath)};
+    rom_ = RomFactory::from_file(filepath);
 
-    MemBankList ppu_membanks{MemBankFactory::create_nes_ppu_mem_banks()};
-
-    ppu_membanks.push_back(std::make_unique<MemBankReference>(rom.get()));
+    MemBankList ppu_membanks{
+            MemBankFactory::create_nes_ppu_mem_banks(rom_.get())};
     ppu_mmu_->set_mem_banks(std::move(ppu_membanks));
 
-    MemBankList cpu_membanks{MemBankFactory::create_nes_mem_banks(ppu_.get())};
-    cpu_membanks.push_back(std::move(rom));
+    MemBankList cpu_membanks{
+            MemBankFactory::create_nes_mem_banks(ppu_.get(), rom_.get())};
     mmu_->set_mem_banks(std::move(cpu_membanks));
 
     reset();

--- a/nes/test/src/test_nes.cpp
+++ b/nes/test/src/test_nes.cpp
@@ -6,19 +6,9 @@ using namespace n_e_s::nes;
 
 namespace {
 
-// This works because opcode 0 does nothing.
-TEST(Nes, the_cycle_count_works) {
+TEST(Nes, inital_state_is_correct) {
     Nes nes;
     EXPECT_EQ(0llu, nes.current_cycle());
-
-    nes.execute();
-    EXPECT_EQ(1llu, nes.current_cycle());
-
-    for (int i = 0; i < 9; ++i) {
-        nes.execute();
-    }
-
-    EXPECT_EQ(10llu, nes.current_cycle());
 }
 
 } // namespace


### PR DESCRIPTION
Had to refactor how we handle the rom in order to distinguish reads on the ppu and cpu buses.