### PR TITLE
Make sure our lambda captures work in both C++20 and C++17

### DIFF
--- a/core/src/membank_factory.cpp
+++ b/core/src/membank_factory.cpp
@@ -9,11 +9,11 @@ namespace n_e_s::core {
 namespace {
 
 auto create_ppu_reader(IPpu *ppu) {
-    return [=](uint16_t addr) { return ppu->read_byte(addr); };
+    return [ppu](uint16_t addr) { return ppu->read_byte(addr); };
 }
 
 auto create_ppu_writer(IPpu *ppu) {
-    return [=](uint16_t addr, uint8_t byte) { ppu->write_byte(addr, byte); };
+    return [ppu](uint16_t addr, uint8_t byte) { ppu->write_byte(addr, byte); };
 }
 
 } // namespace

--- a/core/src/mmu.cpp
+++ b/core/src/mmu.cpp
@@ -9,7 +9,7 @@ namespace n_e_s::core {
 namespace {
 
 auto equal(uint16_t addr) {
-    return [=](const std::unique_ptr<IMemBank> &mem_bank) {
+    return [addr](const std::unique_ptr<IMemBank> &mem_bank) {
         return mem_bank->is_address_in_range(addr);
     };
 }

--- a/core/src/pipeline.cpp
+++ b/core/src/pipeline.cpp
@@ -3,7 +3,7 @@
 namespace n_e_s::core {
 
 void Pipeline::push(const StepT &step) {
-    steps_.emplace_back([=]() {
+    steps_.emplace_back([step]() {
         step();
         return StepResult::Continue;
     });


### PR DESCRIPTION
In C++20 lambdas capturing by value stopped capturing `this`, requiring
you to capture it like `[=, this]` while in C++17 and earlier,
explicitly capturing `this` like `[=, this]` is an error, so I made all
lambda captures explicitly state what they want to capture.