### PR TITLE
Downgrade ninja on Windows

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install cmake==3.16.3 ninja==1.10.0 --upgrade
+          python -m pip install cmake==3.16.3 ninja==1.9.0.post1 --upgrade
           cmake --version
           ninja --version
           echo "Generator: ${{ matrix.generator }}"


### PR DESCRIPTION
* Looks like the Windows wheels were removed from pypi:
  https://github.com/scikit-build/ninja-python-distributions/issues/33