### PR TITLE
Fix CLion warning: use of signed integer w/ binary bitwise operator

### DIFF
--- a/core/include/nes/core/imos6502.h
+++ b/core/include/nes/core/imos6502.h
@@ -8,7 +8,7 @@
 
 namespace n_e_s::core {
 
-enum CpuFlag {
+enum CpuFlag : uint8_t {
     C_FLAG = 1u << 0u, // carry
     Z_FLAG = 1u << 1u, // zero
     I_FLAG = 1u << 2u, // interrupt disable


### PR DESCRIPTION
When testing CLion I was getting a warning on every line where a CPU flag was used. :D