### PR TITLE
Move file loading out of the emulation libraries

### DIFF
--- a/application/src/main.cpp
+++ b/application/src/main.cpp
@@ -1,5 +1,7 @@
 #include "nes/nes.h"
 
+#include <fstream>
+
 using namespace n_e_s::nes;
 
 int main(int argc, char **argv) {
@@ -8,7 +10,8 @@ int main(int argc, char **argv) {
     }
 
     Nes nes;
-    nes.load_rom(argv[1]);
+    std::ifstream fs(argv[1], std::ios::binary);
+    nes.load_rom(fs);
 
     for (uint32_t i = 0; i < 10'000'000; ++i) {
         nes.execute();

--- a/core/include/nes/core/rom_factory.h
+++ b/core/include/nes/core/rom_factory.h
@@ -4,14 +4,11 @@
 
 #include <iosfwd>
 #include <memory>
-#include <string>
 
 namespace n_e_s::core {
 
 class RomFactory {
 public:
-    [[nodiscard]] static std::unique_ptr<IRom> from_file(
-            const std::string &filepath);
     [[nodiscard]] static std::unique_ptr<IRom> from_bytes(
             std::istream &bytestream);
 };

--- a/core/src/rom_factory.cpp
+++ b/core/src/rom_factory.cpp
@@ -4,7 +4,6 @@
 
 #include <cassert>
 #include <cstring>
-#include <fstream>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -30,15 +29,6 @@ size_t streamsize(std::istream &stream) {
 } // namespace
 
 namespace n_e_s::core {
-
-std::unique_ptr<IRom> RomFactory::from_file(const std::string &filepath) {
-    std::ifstream file(filepath, std::ios::binary);
-    if (!file) {
-        throw std::invalid_argument("Unable to open file: " + filepath);
-    }
-
-    return from_bytes(file);
-}
 
 std::unique_ptr<IRom> RomFactory::from_bytes(std::istream &bytestream) {
     std::vector<uint8_t> bytes(streamsize(bytestream));

--- a/core/test/src/test_rom.cpp
+++ b/core/test/src/test_rom.cpp
@@ -40,12 +40,6 @@ std::string nrom_bytes(const uint8_t prg_rom_size, const uint8_t chr_rom_size) {
     return bytes;
 }
 
-TEST(RomFactory, cant_open_files_that_dont_exist) {
-    EXPECT_THROW(auto tmp = RomFactory::from_file(
-                         "this_file_hopefully_doesnt_exist"),
-            std::invalid_argument);
-}
-
 TEST(RomFactory, doesnt_parse_streams_with_too_few_bytes) {
     std::string bytes(15, 0);
     std::stringstream ss(bytes);

--- a/nes/include/nes/nes.h
+++ b/nes/include/nes/nes.h
@@ -25,7 +25,7 @@ public:
     // Run at 263.25 / 11 Mhz for NTSC "realtime."
     void execute();
     void reset();
-    void load_rom(const std::string &filepath);
+    void load_rom(std::istream &bytestream);
 
     n_e_s::core::IMos6502 &cpu();
     const n_e_s::core::IMos6502 &cpu() const;

--- a/nes/src/nes.cpp
+++ b/nes/src/nes.cpp
@@ -10,6 +10,8 @@
 #include "nes/core/ppu_factory.h"
 #include "nes/core/rom_factory.h"
 
+#include <fstream>
+
 using namespace n_e_s::core;
 
 namespace n_e_s::nes {
@@ -72,8 +74,8 @@ void Nes::reset() {
     cpu_->reset();
 }
 
-void Nes::load_rom(const std::string &filepath) {
-    rom_ = RomFactory::from_file(filepath);
+void Nes::load_rom(std::istream &bytestream) {
+    rom_ = RomFactory::from_bytes(bytestream);
 
     MemBankList ppu_membanks{
             MemBankFactory::create_nes_ppu_mem_banks(rom_.get())};

--- a/nestest/src/main.cpp
+++ b/nestest/src/main.cpp
@@ -1,3 +1,4 @@
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <stdexcept>
@@ -116,7 +117,8 @@ int main(int argc, char **argv) {
 
     try {
         n_e_s::nes::Nes nes;
-        nes.load_rom(argv[1]);
+        std::ifstream fs(argv[1], std::ios::binary);
+        nes.load_rom(fs);
         nes.cpu_registers().pc = 0xC000;
 
         n_e_s::core::CpuState prev_state{};


### PR DESCRIPTION
Letting the user deal with opening a file and giving us a stream of
bytes feels less gross and is easier to test.