### PR TITLE
Remove travis build status from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # n e s
 
-[![Travis build status](https://travis-ci.org/evilcorpltd/n_e_s.svg?branch=master)](https://travis-ci.org/evilcorpltd/n_e_s)
-
 ## Description
 
 Modular cycle-accurate NES emulator implemented from scratch in modern C++ and


### PR DESCRIPTION
* We don't use travis for CI anymore.