### PR TITLE
Remove copts from bazel build files

### DIFF
--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -1,3 +1,5 @@
+load(":defs.bzl", "private_include_copts")
+
 cc_library(
     name = "core",
     srcs = glob([
@@ -6,7 +8,7 @@ cc_library(
     hdrs = glob([
         "include/**/*.h",
     ]),
-    copts = ["-Icore/src"],
+    copts = private_include_copts(["src/"]),
     strip_include_prefix = "include/",
     visibility = ["//visibility:public"],
 )

--- a/core/defs.bzl
+++ b/core/defs.bzl
@@ -1,0 +1,18 @@
+
+# From: https://github.com/bazelbuild/bazel/issues/2670
+def private_include_copts(includes):
+    copts = []
+    prefix = ''
+
+    # convert "@" to "external/" unless in the main workspace
+    repo_name = native.repository_name()
+    package_name = native.package_name()
+    if repo_name != '@':
+        prefix = 'external/{}/'.format(repo_name[1:])
+
+    for inc in includes:
+        copts.append("-I{}{}/{}".format(prefix, package_name, inc))
+        copts.append("-I$(GENDIR)/{}{}/{}".format(prefix, package_name, inc))
+
+    return copts
+

--- a/disassembler/BUILD.bazel
+++ b/disassembler/BUILD.bazel
@@ -6,7 +6,6 @@ cc_library(
     hdrs = glob([
         "include/**/*.h",
     ]),
-    copts = ["-Idisassembler/src"],
     strip_include_prefix = "include/",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
* copts does not work well if the repo is included as an external repo.
* See https://github.com/bazelbuild/bazel/issues/2670