### PR TITLE
Fix build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,13 @@ workspace(name = "nes")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 
+# v1.10.0 + fix for build failing due to std::result_of being removed in C++20.
+# See: https://github.com/google/googletest/commit/61f010d703b32de9bfb20ab90ece38ab2f25977f
 git_repository(
     name = "gtest",
-    commit = "703bd9caab50b139428cea1aaff9974ebee5742e",
+    commit = "61f010d703b32de9bfb20ab90ece38ab2f25977f",
     remote = "https://github.com/google/googletest",
-    shallow_since = "1570114335 -0400",
+    shallow_since = "1585697018 -0400",
 )
 
 new_git_repository(

--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -1,9 +1,11 @@
 include(FetchContent)
 
+# v1.10.0 + fix for build failing due to std::result_of being removed in C++20.
+# See: https://github.com/google/googletest/commit/61f010d703b32de9bfb20ab90ece38ab2f25977f
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        e3f0319d89f4cbf32993de595d984183b1a9fc57 # 1.10 + build fix for clang on Windows
+    GIT_TAG        61f010d703b32de9bfb20ab90ece38ab2f25977f
 )
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
The version of Google Test we were using was using std::result_of which
was removed in C++20.