### PR TITLE
Skip first cycle on odd frames

### DIFF
--- a/core/include/nes/core/ppu_registers.h
+++ b/core/include/nes/core/ppu_registers.h
@@ -168,6 +168,7 @@ struct PpuRegisters {
     PpuVram vram_addr;
     PpuVram temp_vram_addr;
     bool write_toggle;
+    bool odd_frame;
 
     uint8_t name_table_latch;
     uint8_t name_table;

--- a/core/src/ppu.cpp
+++ b/core/src/ppu.cpp
@@ -162,6 +162,11 @@ void Ppu::update_counters() {
         cycle() = 0;
         if (scanline() == kLastScanlineInFrame) {
             scanline() = 0;
+            registers_->odd_frame = !registers_->odd_frame;
+            if (registers_->odd_frame &&
+                    registers_->mask.is_rendering_enabled()) {
+                cycle() = 1;
+            }
         } else {
             ++scanline();
         }

--- a/core/test/src/ippu_helpers.cpp
+++ b/core/test/src/ippu_helpers.cpp
@@ -10,7 +10,7 @@ bool operator==(const PpuRegisters &a, const PpuRegisters &b) {
            a.mask == b.mask && a.status == b.status && a.oamaddr == b.oamaddr &&
            a.fine_x_scroll == b.fine_x_scroll && a.vram_addr == b.vram_addr &&
            a.temp_vram_addr == b.temp_vram_addr &&
-           a.write_toggle == b.write_toggle;
+           a.write_toggle == b.write_toggle && a.odd_frame == b.odd_frame;
 }
 
 // Required by gtest to use pascal case.
@@ -20,7 +20,7 @@ void PrintTo(const PpuRegisters &r, std::ostream *os) {
             "Cycle: {} Scanline: {} Ctrl: {:#04x} ScrollX: {:#04x} Mask: "
             "{:#04x} OamAddr: {:#04x} "
             "Status: {:#04x} VramAddr: {:#06x} TmpVramAddr: {:#06x} "
-            "WriteToggle: {}\n",
+            "WriteToggle: {} OddFrame: {}\n",
             r.cycle,
             r.scanline,
             r.ctrl,
@@ -30,7 +30,8 @@ void PrintTo(const PpuRegisters &r, std::ostream *os) {
             r.status,
             r.vram_addr.value(),
             r.temp_vram_addr.value(),
-            r.write_toggle);
+            r.write_toggle,
+            r.odd_frame);
 }
 
 } // namespace n_e_s::core


### PR DESCRIPTION
* When rendering is enabled, each odd ppu frame is one clock shorter
  than normal. This is done by skipping the first idle tick on the first
  visible scanline.
  See: https://www.nesdev.org/wiki/PPU_frame_timing