### PR TITLE
Automate --config flag setup when building with Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 build --color=yes
+build --enable_platform_specific_config
 test --test_output=errors
 test --test_verbose_timeout_warnings=true
 
-build:gnulike --cxxopt="-std=c++2a"
-build:msvc --cxxopt="/std:c++latest"
+build:linux --cxxopt="-std=c++2a"
+build:windows --cxxopt="/std:c++latest"

--- a/.github/workflows/ci-bazel.yaml
+++ b/.github/workflows/ci-bazel.yaml
@@ -10,4 +10,4 @@ jobs:
     - name: Test
       run: |
         bazel --version
-        CC=gcc-10 CXX=g++-10 bazel test ... --config=gnulike
+        CC=gcc-10 CXX=g++-10 bazel test ...


### PR DESCRIPTION
Passing `--enable_platform_specific_config` means that `windows` and `linux` options are automatically pulled in on the respective platform.