### PR TITLE
Fix CMake 4.x build

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -56,6 +56,7 @@ jobs:
             version: "14"
             configuration: Debug
             cmake-args: -DADDRESS_SANITIZER=ON -DUNDEFINED_SANITIZER=ON
+            apt-extras: libclang-rt-14-dev
 
     steps:
       - uses: actions/checkout@v3
@@ -75,7 +76,7 @@ jobs:
             echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
           else
             curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s ${{ matrix.version }}
-            sudo apt-get install -y clang-tidy-${{ matrix.version }} g++-multilib
+            sudo apt-get install -y clang-tidy-${{ matrix.version }} g++-multilib ${{ matrix.apt-extras }}
             echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
             echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
           fi
@@ -104,7 +105,7 @@ jobs:
       - name: Coverage
         if: matrix.coverage
         run: |
-          pip install gcovr
+          pip install gcovr==5.1
           (cd build && gcovr --gcov-executable gcov-10 -p --root .. --fail-under-line=94 --exclude 'CMakeFiles/' --exclude '_deps/' --exclude '(.+/)?test/' --exclude '.+/(application|nestest)/')
 
       - name: Clang-tidy

--- a/.github/workflows/ci-nestest.yaml
+++ b/.github/workflows/ci-nestest.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload artifacts
         if: matrix.nestest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nestest-log
           path: nestest-output.log

--- a/third_party/gtest/CMakeLists.txt
+++ b/third_party/gtest/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        e2239ee6043f73722e7aa812a459f54a28552929 # v.1.11.0
+    GIT_TAG        6910c9d9165801d8827d628cb72eb7ea9dd538c5 # v.1.16.0
 )
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
gtest was still setting its cmake version to 2.8 in v1.11.0, and CMake 4 dropped support for anything older than CMake 3.5.